### PR TITLE
Use RSA ACM certificate for CloudFront

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -51,29 +51,26 @@ jobs:
       - name: Setup Pulumi CLI
         uses: pulumi/setup-pulumi@v2
 
-      - name: Create or select stack
+      - name: Select stack
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          PULUMI_STACK: ${{ secrets.PULUMI_STACK }}
         run: |
-          pulumi stack select "$PULUMI_STACK" --cwd infrastructure --create
-          pulumi config set aws:region "$AWS_REGION" --cwd infrastructure --stack "$PULUMI_STACK"
+          pulumi stack select sean1588/minicode-site/dev --cwd infrastructure
+          pulumi config set aws:region "$AWS_REGION" --cwd infrastructure --stack sean1588/minicode-site/dev
 
       - name: Deploy infrastructure
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          PULUMI_STACK: ${{ secrets.PULUMI_STACK }}
-        run: pulumi up --yes --cwd infrastructure --stack "$PULUMI_STACK"
+        run: pulumi up --yes --cwd infrastructure --stack sean1588/minicode-site/dev
 
       - name: Read infrastructure outputs
         id: infra
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          PULUMI_STACK: ${{ secrets.PULUMI_STACK }}
         run: |
-          echo "bucket=$(pulumi stack output siteBucketName --cwd infrastructure --stack "$PULUMI_STACK")" >> "$GITHUB_OUTPUT"
-          echo "cdn_id=$(pulumi stack output siteCdnId --cwd infrastructure --stack "$PULUMI_STACK")" >> "$GITHUB_OUTPUT"
-          echo "site_url=$(pulumi stack output siteUrl --cwd infrastructure --stack "$PULUMI_STACK")" >> "$GITHUB_OUTPUT"
+          echo "bucket=$(pulumi stack output siteBucketName --cwd infrastructure --stack sean1588/minicode-site/dev)" >> "$GITHUB_OUTPUT"
+          echo "cdn_id=$(pulumi stack output siteCdnId --cwd infrastructure --stack sean1588/minicode-site/dev)" >> "$GITHUB_OUTPUT"
+          echo "site_url=$(pulumi stack output siteUrl --cwd infrastructure --stack sean1588/minicode-site/dev)" >> "$GITHUB_OUTPUT"
 
       - name: Build Hugo site
         working-directory: site

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -54,7 +54,6 @@ jobs:
       - name: Create or select stack
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
           PULUMI_STACK: ${{ secrets.PULUMI_STACK }}
         run: |
           pulumi stack select "$PULUMI_STACK" --cwd infrastructure --create
@@ -63,7 +62,6 @@ jobs:
       - name: Deploy infrastructure
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
           PULUMI_STACK: ${{ secrets.PULUMI_STACK }}
         run: pulumi up --yes --cwd infrastructure --stack "$PULUMI_STACK"
 
@@ -71,7 +69,6 @@ jobs:
         id: infra
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
           PULUMI_STACK: ${{ secrets.PULUMI_STACK }}
         run: |
           echo "bucket=$(pulumi stack output siteBucketName --cwd infrastructure --stack "$PULUMI_STACK")" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -1,20 +1,24 @@
-name: Deploy Site
+name: Preview Site
 
 on:
-  push:
+  pull_request:
     branches: [main]
     paths:
       - 'site/**'
       - 'infrastructure/**'
       - '.github/workflows/deploy-site.yml'
+      - '.github/workflows/preview-site.yml'
   workflow_dispatch:
 
 env:
   AWS_REGION: us-west-2
-  HUGO_VERSION: '0.147.6'
+
+concurrency:
+  group: preview-site-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  deploy:
+  preview:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -35,12 +39,6 @@ jobs:
         working-directory: infrastructure
         run: npm ci
 
-      - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v3
-        with:
-          hugo-version: ${{ env.HUGO_VERSION }}
-          extended: true
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -60,38 +58,9 @@ jobs:
           pulumi stack select "$PULUMI_STACK" --cwd infrastructure --create
           pulumi config set aws:region "$AWS_REGION" --cwd infrastructure --stack "$PULUMI_STACK"
 
-      - name: Deploy infrastructure
+      - name: Preview infrastructure
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
           PULUMI_STACK: ${{ secrets.PULUMI_STACK }}
-        run: pulumi up --yes --cwd infrastructure --stack "$PULUMI_STACK"
-
-      - name: Read infrastructure outputs
-        id: infra
-        env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
-          PULUMI_STACK: ${{ secrets.PULUMI_STACK }}
-        run: |
-          echo "bucket=$(pulumi stack output siteBucketName --cwd infrastructure --stack "$PULUMI_STACK")" >> "$GITHUB_OUTPUT"
-          echo "cdn_id=$(pulumi stack output siteCdnId --cwd infrastructure --stack "$PULUMI_STACK")" >> "$GITHUB_OUTPUT"
-          echo "site_url=$(pulumi stack output siteUrl --cwd infrastructure --stack "$PULUMI_STACK")" >> "$GITHUB_OUTPUT"
-
-      - name: Build Hugo site
-        working-directory: site
-        env:
-          HUGO_BASEURL: ${{ steps.infra.outputs.site_url }}
-        run: hugo --minify --baseURL "$HUGO_BASEURL"
-
-      - name: Sync files to S3
-        run: |
-          aws s3 sync site/public/ s3://${{ steps.infra.outputs.bucket }}/ \
-            --delete \
-            --cache-control "public, max-age=300, s-maxage=300"
-
-      - name: Invalidate CloudFront
-        run: |
-          aws cloudfront create-invalidation \
-            --distribution-id ${{ steps.infra.outputs.cdn_id }} \
-            --paths '/*'
+        run: pulumi preview --diff --cwd infrastructure --stack "$PULUMI_STACK" --non-interactive

--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -49,16 +49,14 @@ jobs:
       - name: Setup Pulumi CLI
         uses: pulumi/setup-pulumi@v2
 
-      - name: Create or select stack
+      - name: Select stack
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          PULUMI_STACK: ${{ secrets.PULUMI_STACK }}
         run: |
-          pulumi stack select "$PULUMI_STACK" --cwd infrastructure --create
-          pulumi config set aws:region "$AWS_REGION" --cwd infrastructure --stack "$PULUMI_STACK"
+          pulumi stack select sean1588/minicode-site/dev --cwd infrastructure
+          pulumi config set aws:region "$AWS_REGION" --cwd infrastructure --stack sean1588/minicode-site/dev
 
       - name: Preview infrastructure
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          PULUMI_STACK: ${{ secrets.PULUMI_STACK }}
-        run: pulumi preview --diff --cwd infrastructure --stack "$PULUMI_STACK" --non-interactive
+        run: pulumi preview --diff --cwd infrastructure --stack sean1588/minicode-site/dev --non-interactive

--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -52,7 +52,6 @@ jobs:
       - name: Create or select stack
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
           PULUMI_STACK: ${{ secrets.PULUMI_STACK }}
         run: |
           pulumi stack select "$PULUMI_STACK" --cwd infrastructure --create
@@ -61,6 +60,5 @@ jobs:
       - name: Preview infrastructure
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
           PULUMI_STACK: ${{ secrets.PULUMI_STACK }}
         run: pulumi preview --diff --cwd infrastructure --stack "$PULUMI_STACK" --non-interactive

--- a/infrastructure/Pulumi.dev.yaml
+++ b/infrastructure/Pulumi.dev.yaml
@@ -3,4 +3,3 @@ config:
   minicode-site:domainName: minicode.seanholung.com
   minicode-site:hostedZoneName: seanholung.com
   minicode-site:certificateArn: arn:aws:acm:us-east-1:127590312302:certificate/16e3cd20-3661-4c77-a4f1-550be34e93f9
-encryptionsalt: v1:vpSlOy4gWM4=:v1:5b6qPpBQ4WbFJz7k:6HrnaoSS5zC/ItxrGhsOt5JLY7hEFw==

--- a/infrastructure/Pulumi.dev.yaml
+++ b/infrastructure/Pulumi.dev.yaml
@@ -2,4 +2,4 @@ config:
   aws:region: us-west-2
   minicode-site:domainName: minicode.seanholung.com
   minicode-site:hostedZoneName: seanholung.com
-  minicode-site:certificateArn: arn:aws:acm:us-east-1:127590312302:certificate/16e3cd20-3661-4c77-a4f1-550be34e93f9
+  minicode-site:certificateArn: arn:aws:acm:us-east-1:127590312302:certificate/2b25457c-334d-4e02-b013-a49994f5e67a

--- a/infrastructure/Pulumi.dev.yaml
+++ b/infrastructure/Pulumi.dev.yaml
@@ -2,4 +2,5 @@ config:
   aws:region: us-west-2
   minicode-site:domainName: minicode.seanholung.com
   minicode-site:hostedZoneName: seanholung.com
+  minicode-site:certificateArn: arn:aws:acm:us-east-1:127590312302:certificate/16e3cd20-3661-4c77-a4f1-550be34e93f9
 encryptionsalt: v1:vpSlOy4gWM4=:v1:5b6qPpBQ4WbFJz7k:6HrnaoSS5zC/ItxrGhsOt5JLY7hEFw==

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -6,7 +6,8 @@ Pulumi IaC for deploying the Hugo site to a private S3 bucket behind CloudFront,
 
 - Pulumi CLI
 - AWS credentials with permissions for S3 + CloudFront + IAM policy updates
-- Pulumi access token
+- Pulumi access token when using the Pulumi Cloud backend
+- `PULUMI_CONFIG_PASSPHRASE` when using the current passphrase-encrypted stack config
 
 ## Quickstart
 
@@ -14,12 +15,18 @@ Pulumi IaC for deploying the Hugo site to a private S3 bucket behind CloudFront,
 cd infrastructure
 npm install
 pulumi stack init dev # first time only
+export PULUMI_CONFIG_PASSPHRASE=your-stack-passphrase
 pulumi config set aws:region us-west-2
 # optional overrides (defaults are already set in Pulumi.dev.yaml)
 pulumi config set minicode-site:domainName minicode.seanholung.com
 pulumi config set minicode-site:hostedZoneName seanholung.com
+# optional: reuse an existing ACM certificate for CloudFront
+# this must be for the site domain and must live in us-east-1
+pulumi config set minicode-site:certificateArn arn:aws:acm:us-east-1:123456789012:certificate/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 pulumi up
 ```
+
+If `minicode-site:certificateArn` is omitted, the program will create and DNS-validate a new ACM certificate in `us-east-1` using the configured Route53 hosted zone.
 
 ## Outputs
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -7,7 +7,6 @@ Pulumi IaC for deploying the Hugo site to a private S3 bucket behind CloudFront,
 - Pulumi CLI
 - AWS credentials with permissions for S3 + CloudFront + IAM policy updates
 - Pulumi access token when using the Pulumi Cloud backend
-- `PULUMI_CONFIG_PASSPHRASE` when using the current passphrase-encrypted stack config
 
 ## Quickstart
 
@@ -15,7 +14,6 @@ Pulumi IaC for deploying the Hugo site to a private S3 bucket behind CloudFront,
 cd infrastructure
 npm install
 pulumi stack init dev # first time only
-export PULUMI_CONFIG_PASSPHRASE=your-stack-passphrase
 pulumi config set aws:region us-west-2
 # optional overrides (defaults are already set in Pulumi.dev.yaml)
 pulumi config set minicode-site:domainName minicode.seanholung.com

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -5,6 +5,27 @@ const config = new pulumi.Config();
 const siteName = config.get("siteName") || "minicode-site";
 const domainName = config.get("domainName") || "minicode.seanholung.com";
 const hostedZoneName = config.get("hostedZoneName") || "seanholung.com";
+const configuredCertificateArn = config.get("certificateArn");
+
+function validateCloudFrontCertificateArn(certificateArn: string): string {
+  const arnParts = certificateArn.split(":");
+
+  if (arnParts.length < 6 || arnParts[2] !== "acm") {
+    throw new Error(
+      `minicode-site:certificateArn must be an ACM certificate ARN. Received "${certificateArn}".`
+    );
+  }
+
+  const certificateRegion = arnParts[3];
+
+  if (certificateRegion !== "us-east-1") {
+    throw new Error(
+      `CloudFront requires ACM certificates in us-east-1. Received "${certificateRegion}" in minicode-site:certificateArn.`
+    );
+  }
+
+  return certificateArn;
+}
 
 const usEast1 = new aws.Provider("us-east-1", {
   region: "us-east-1",
@@ -39,38 +60,52 @@ const oac = new aws.cloudfront.OriginAccessControl("site-oac", {
   signingProtocol: "sigv4",
 });
 
-const certificate = new aws.acm.Certificate(
-  "site-certificate",
-  {
-    domainName,
-    validationMethod: "DNS",
-    tags: {
-      Project: siteName,
-      Component: "marketing-site",
+const existingCertificateArn = configuredCertificateArn
+  ? validateCloudFrontCertificateArn(configuredCertificateArn)
+  : undefined;
+
+let viewerCertificateArn: pulumi.Input<string>;
+const certificateDependencies: pulumi.Resource[] = [];
+
+if (existingCertificateArn) {
+  viewerCertificateArn = existingCertificateArn;
+} else {
+  const certificate = new aws.acm.Certificate(
+    "site-certificate",
+    {
+      domainName,
+      validationMethod: "DNS",
+      tags: {
+        Project: siteName,
+        Component: "marketing-site",
+      },
     },
-  },
-  { provider: usEast1 }
-);
+    { provider: usEast1 }
+  );
 
-const certificateValidationOption = certificate.domainValidationOptions[0];
+  const certificateValidationOption = certificate.domainValidationOptions[0];
 
-const certificateValidationRecord = new aws.route53.Record("site-certificate-validation", {
-  zoneId: hostedZone.zoneId,
-  name: certificateValidationOption.resourceRecordName,
-  type: certificateValidationOption.resourceRecordType,
-  records: [certificateValidationOption.resourceRecordValue],
-  ttl: 60,
-  allowOverwrite: true,
-});
+  const certificateValidationRecord = new aws.route53.Record("site-certificate-validation", {
+    zoneId: hostedZone.zoneId,
+    name: certificateValidationOption.resourceRecordName,
+    type: certificateValidationOption.resourceRecordType,
+    records: [certificateValidationOption.resourceRecordValue],
+    ttl: 60,
+    allowOverwrite: true,
+  });
 
-const certificateValidation = new aws.acm.CertificateValidation(
-  "site-certificate-validation-result",
-  {
-    certificateArn: certificate.arn,
-    validationRecordFqdns: [certificateValidationRecord.fqdn],
-  },
-  { provider: usEast1 }
-);
+  const certificateValidation = new aws.acm.CertificateValidation(
+    "site-certificate-validation-result",
+    {
+      certificateArn: certificate.arn,
+      validationRecordFqdns: [certificateValidationRecord.fqdn],
+    },
+    { provider: usEast1 }
+  );
+
+  viewerCertificateArn = certificate.arn;
+  certificateDependencies.push(certificateValidation);
+}
 
 const cdn = new aws.cloudfront.Distribution("site-cdn", {
   enabled: true,
@@ -112,7 +147,7 @@ const cdn = new aws.cloudfront.Distribution("site-cdn", {
     geoRestriction: { restrictionType: "none" },
   },
   viewerCertificate: {
-    acmCertificateArn: certificate.arn,
+    acmCertificateArn: viewerCertificateArn,
     sslSupportMethod: "sni-only",
     minimumProtocolVersion: "TLSv1.2_2021",
   },
@@ -120,7 +155,7 @@ const cdn = new aws.cloudfront.Distribution("site-cdn", {
     Project: siteName,
     Component: "marketing-site",
   },
-}, { dependsOn: [certificateValidation] });
+}, { dependsOn: certificateDependencies });
 
 new aws.s3.BucketPolicy("site-policy", {
   bucket: siteBucket.id,


### PR DESCRIPTION
## Summary
- switch the stack config to the issued RSA ACM certificate in us-east-1
- keep the existing custom domain wiring but use a CloudFront-compatible cert
- preserve the PR preview/deploy workflow changes already merged previously

## Why
CloudFront was rejecting the prior certificate with . The certificate was issued, but it used , which CloudFront does not accept for viewer certificates. This follow-up points the stack at a new  ACM certificate, which fixes the deploy and serves  successfully.

## Verification
- manual deploy workflow succeeded: https://github.com/sean1588/minicode-site/actions/runs/23700805877
-  returns 
- CloudFront distribution  is using the  RSA cert and alias 
