### PR TITLE
Add docs site and refine landing page

### DIFF
--- a/site/content/docs/_index.md
+++ b/site/content/docs/_index.md
@@ -1,0 +1,17 @@
+---
+title: Documentation
+description: A first-pass reference for getting started with minicode, understanding the CLI and config, and digging into the runtime and graph-oriented architecture.
+weight: 1
+---
+
+minicode started as a way to make smaller local models more effective for coding work, then expanded into a broader agent runtime with a graph-native web UI and an OpenAI-compatible server mode. The docs here are a curated first pass built from the main `README.md` and the existing technical documents in the core repository.
+
+Use this section to:
+
+- get a local setup running quickly
+- learn the main CLI and serve-mode workflows
+- configure the agent for local or hosted backends
+- understand the runtime, context management, and graph-aware tooling
+- explore the plugin and SDK direction
+
+The current information architecture is intentionally simple. We can reshape the categories later once the docs footprint grows.

--- a/site/content/docs/agent-runtime-sdk.md
+++ b/site/content/docs/agent-runtime-sdk.md
@@ -1,0 +1,180 @@
+---
+title: Agent Runtime SDK
+description: A dedicated overview of the `@minicode/agent-sdk` package, including its current status, core exports, and how to build on top of it.
+weight: 55
+kicker: SDK
+---
+
+The `minicode` repository includes a dedicated SDK package at [packages/agent-sdk](/mnt/c/Users/seanh/Documents/codex-projects/minicode/packages/agent-sdk). It packages the reusable parts of the runtime so the CLI can be just one consumer among others.
+
+## Current status
+
+The SDK is real code, not just a concept. It already has:
+
+- a dedicated README
+- a package boundary
+- exported runtime types and classes
+- built-in core tools
+- model clients for Anthropic and OpenAI-compatible providers
+
+One important detail from the current repo state: [package.json](/mnt/c/Users/seanh/Documents/codex-projects/minicode/packages/agent-sdk/package.json) is still marked `private`. So the package exists and is documented, but it is not yet a normal published npm package in the current source tree.
+
+## What it includes
+
+From the current exports in [src/index.ts](/mnt/c/Users/seanh/Documents/codex-projects/minicode/packages/agent-sdk/src/index.ts), the SDK exposes:
+
+- core runtime types such as `AgentConfig`, `ModelClient`, `ModelResponse`, `ToolDefinition`, and `SessionMessage`
+- the `CodingAgent` class and UI update event types
+- `Session` and compaction-related types
+- `AnthropicModelClient`, `OpenAICompatibleModelClient`, and `createModelClient`
+- `ToolRegistry` plus `CoreToolHooks`
+- the built-in core tool factories
+- safety and guardrail helpers
+- `buildSystemPrompt`
+- `FocusTracker`
+- indexer and plugin types such as `LanguagePlugin`, `IndexedSymbol`, and `DependencyEdge`
+
+That makes the package useful both for building new agent runtimes and for building adjacent tooling around the same message, tool, and graph model.
+
+## What it does not include
+
+The SDK exports indexer and plugin _types_, but it does not currently ship the full `minicode` project indexer implementation that the CLI uses for TypeScript-aware graph tools.
+
+In practice, that means:
+
+- the SDK can give you the reusable runtime core
+- the CLI repo still carries the richer project-index and serve-mode implementation
+- if you want symbol-aware graph tooling in another app today, you would still need to bring over or extract more of the `minicode` indexer layer
+
+## Core building blocks
+
+### `CodingAgent`
+
+`CodingAgent` is the main turn-based runtime. It sends messages to the model, executes tool calls, appends results to session history, and stops when it reaches a final answer or a guardrail condition.
+
+### `Session`
+
+`Session` stores conversation history and supports trimming and compaction. This is part of what makes the SDK useful beyond one-shot prompting: it has explicit long-running session behavior rather than forcing each consumer to invent its own.
+
+### `ToolRegistry`
+
+`ToolRegistry` handles tool registration, schema generation, and execution. In the current implementation it supports:
+
+- `ToolRegistry.createDefault(config)` for the built-in core tools
+- custom registries created from your own `ToolDefinition[]`
+
+The default SDK tool set is the general-purpose core layer:
+
+- `read_file`
+- `write_file`
+- `edit_file`
+- `search`
+- `list_files`
+- `run_command`
+
+### Model clients
+
+The SDK currently exposes:
+
+- `AnthropicModelClient`
+- `OpenAICompatibleModelClient`
+- `createModelClient(config)`
+
+That lets consumers keep a stable runtime model while swapping the provider transport underneath.
+
+## Typical usage
+
+The SDK README shows the intended flow clearly:
+
+1. define an `AgentConfig`
+2. create a model client
+3. create a tool registry
+4. construct a `CodingAgent`
+5. call `runTurn(...)`
+
+At a high level, that looks like:
+
+```ts
+import {
+  CodingAgent,
+  ToolRegistry,
+  createModelClient,
+} from "@minicode/agent-sdk";
+
+const toolRegistry = ToolRegistry.createDefault(config);
+const modelClient = createModelClient(config);
+const agent = new CodingAgent({ config, modelClient, toolRegistry });
+
+const result = await agent.runTurn("What files are in this project?");
+console.log(result.text);
+```
+
+## OpenAI-compatible backends
+
+One of the practical strengths of the SDK is that it supports generic OpenAI-compatible providers, not just one hosted API. The README explicitly calls out use with:
+
+- Ollama
+- LM Studio
+- OpenRouter
+- other OpenAI-compatible endpoints
+
+That lines up well with the broader `minicode` story: local-first origins, but a runtime architecture that works across local and hosted models.
+
+## Streaming and UI hooks
+
+The runtime can emit:
+
+- simple progress callbacks via `onProgress`
+- structured UI events via `onUiUpdate`
+
+Those structured updates are what make it possible to build richer frontends on top of the same runtime loop instead of treating the agent as a black box.
+
+The current SDK exports UI event types alongside `CodingAgent`, which is a strong signal that the package is already designed to support UI consumers, not just terminal scripts.
+
+## Custom tools and hooks
+
+The SDK supports custom tools through `ToolDefinition`, and the built-in tool registry can be extended or replaced.
+
+For integrations that maintain their own project index, `CoreToolHooks` let you respond to:
+
+- writes
+- edits
+
+That is the bridge between the runtime package and a richer application layer that wants to keep indexes or metadata up to date.
+
+## Safety model
+
+The SDK includes guardrails that are useful even outside the `minicode` CLI:
+
+- workspace path containment
+- destructive-command detection
+- command denylist enforcement
+- file-size checks
+- step limits
+- loop detection
+
+These helpers are exported directly, so consumers can reuse the same safety model or extend it.
+
+## Relationship to the broader minicode architecture
+
+The SDK sits underneath the broader product story:
+
+- the CLI uses the runtime and adds the project indexer plus symbol-aware tools
+- the web app uses the same core runtime behavior with a richer event-driven UI
+- the draft SDK architecture points toward a future where those layers are more cleanly split into reusable packages
+
+So the SDK is best understood as the reusable core of the system, while the rest of `minicode` adds graph-aware indexing, serve mode, and the product-facing UI.
+
+## When to use this page versus the technical docs
+
+Use this page when you want to understand:
+
+- what the SDK package already contains
+- how close it is to being reusable independently
+- how the exported API is organized today
+
+Use the technical docs when you want the deeper system story:
+
+- [Runtime Architecture](/docs/technical/runtime-architecture/)
+- [Context Optimization](/docs/technical/context-optimization/)
+- [Indexing and Graph](/docs/technical/indexing-and-graph/)

--- a/site/content/docs/cli-reference.md
+++ b/site/content/docs/cli-reference.md
@@ -1,0 +1,133 @@
+---
+title: CLI Reference
+description: The main command-line entry points, common flags, and the development scripts that ship with the repository.
+weight: 20
+kicker: Reference
+---
+
+The CLI has three primary modes:
+
+- interactive terminal use
+- serve mode for the web UI and OpenAI-compatible backend
+- one-shot mode for scripting and automation
+
+## Interactive usage
+
+Run `minicode` from the project you want the agent to work in:
+
+```bash
+cd /path/to/your/project
+minicode
+```
+
+You can also provide the initial task on launch:
+
+```bash
+minicode "Add error handling to src/api.ts"
+```
+
+## Serve mode
+
+Serve mode starts the browser UI plus the local server surfaces:
+
+```bash
+minicode serve
+minicode serve --port 8080
+```
+
+This mode exposes:
+
+- the web chat UI
+- session management
+- graph and symbol endpoints
+- the OpenAI-compatible `/v1/chat/completions` API
+
+It is mutually exclusive with `--oneshot`, `--json`, and `--out`.
+
+## One-shot mode
+
+Use one-shot mode when you want minicode to run a task and exit:
+
+```bash
+minicode --oneshot "Fix lint errors and explain changes"
+minicode -1 "Refactor parseArgs and run tests"
+```
+
+Useful flags:
+
+```bash
+minicode --oneshot --json "Summarize TODOs"
+minicode --oneshot --out result.txt "Draft changelog"
+```
+
+## Verbose mode
+
+Verbose mode logs prompts, model responses, and tool invocations to stderr:
+
+```bash
+minicode --verbose "Fix the bug"
+minicode -v
+```
+
+In development:
+
+```bash
+npm run dev -- --verbose "Fix the bug"
+```
+
+## Interactive slash commands
+
+The interactive CLI also exposes built-in slash commands:
+
+| Command | Purpose |
+| --- | --- |
+| `/help` | Show the available commands |
+| `/config` | Print the active runtime configuration |
+| `/compact` | Compact older session history |
+| `/reasoning [level]` | View or change reasoning effort |
+| `/models` | List provider models when model listing is supported |
+| `/model [name]` | Show or switch the active model |
+| `/save [label]` | Save the current session |
+| `/load [label]` | Restore a saved session |
+| `/sessions` | List saved sessions |
+| `/exit` | Quit the session |
+
+Valid reasoning levels are:
+
+- `xhigh`
+- `high`
+- `medium`
+- `low`
+- `minimal`
+- `none`
+- `off` to clear the override
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Success |
+| `1` | Runtime failure |
+| `2` | CLI usage or validation error |
+
+One example of a usage error is calling `--oneshot` without a prompt.
+
+## Repository scripts
+
+If you are working on minicode itself, the repository exposes these scripts:
+
+| Script | Purpose |
+| --- | --- |
+| `npm run dev` | Build the web client and start the CLI from TypeScript source |
+| `npm run dev:ink` | Start the CLI with Ink UI forced on |
+| `npm run build` | Compile TypeScript to `dist/` |
+| `npm start` | Run the compiled CLI |
+| `npm run lint` | Run ESLint on source and tests |
+| `npm test` | Run the Node test suite |
+| `npm run verify-index` | Run the index verification program |
+
+## Related docs
+
+- [Get Started](/docs/get-started/)
+- [Configuration](/docs/configuration/)
+- [Web UI and Serve Mode](/docs/web-ui-and-serve/)

--- a/site/content/docs/configuration.md
+++ b/site/content/docs/configuration.md
@@ -1,0 +1,120 @@
+---
+title: Configuration
+description: Where minicode reads its settings from, which environment variables it supports, and how to tune it for tighter model context windows.
+weight: 30
+kicker: Reference
+---
+
+minicode keeps its configuration and cache outside your project directory. That lets you reuse the same setup across workspaces while keeping project roots clean.
+
+## Configuration precedence
+
+Later sources override earlier ones:
+
+1. `~/.minicode/.env`
+2. `~/.minicode/agent.config.json`
+3. project `.env` and `agent.config.json` in the workspace root
+4. environment variables in the active shell
+
+The cache lives under `~/.minicode/cache/<workspace-hash>/`.
+
+## Environment variables
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `MODEL_PROVIDER` | `openai-compatible` | `anthropic` or `openai-compatible`; aliases include `openai`, `lmstudio`, and `lm-studio` |
+| `MODEL` | `zai-org/glm-4.7-flash` | Model name for the configured provider |
+| `ANTHROPIC_API_KEY` | none | Required when `MODEL_PROVIDER=anthropic` |
+| `OPENAI_BASE_URL` | `http://localhost:1234/v1` | Base URL for LM Studio or another compatible endpoint |
+| `OPENAI_API_KEY` | none | Optional for local servers, required when the endpoint enforces auth |
+| `OPENROUTER_API_KEY` | none | Used when `OPENAI_BASE_URL` points at OpenRouter; preferred over `OPENAI_API_KEY` there |
+| `MAX_STEPS` | `50` | Max loop iterations per user turn |
+| `MAX_TOKENS` | `4096` | Max output tokens per model call |
+| `MAX_CONTEXT_TOKENS` | `40000` | Approximate session trimming target |
+| `MAX_TOOL_OUTPUT_CHARS` | `8000` | Max characters per tool result before truncation |
+| `WORKSPACE_ROOT` | current directory | Root directory tools can access |
+| `COMMAND_TIMEOUT_MS` | `30000` | Timeout for search and shell commands |
+| `MAX_FILE_SIZE_BYTES` | `1000000` | Read limit for `read_file` |
+| `CONFIRM_DESTRUCTIVE` | `true` | Blocks destructive shell commands unless confirmed |
+| `KEEP_RECENT_MESSAGES` | `12` | Minimum recent messages preserved during trimming |
+| `LOOP_DETECTION_WINDOW` | `6` | Window used for repeated tool-call detection |
+| `ENABLE_FILE_READ_DEDUP` | `true` | Deduplicate repeated `read_file` calls within a turn |
+| `ENABLE_ADAPTIVE_KEEP_RECENT` | `true` | Scale the protected recent-message window as context fills up |
+| `ENABLE_TOOL_OUTPUT_TRUNCATION` | `true` | Apply content-aware truncation strategies to tool output |
+| `COMPACTION_THRESHOLD` | `0.8` | Auto-compaction threshold as a fraction of context fullness |
+| `COMPACTION_MODEL` | none | Optional model used for LLM-based compaction |
+| `REASONING_EFFORT` | none | Optional reasoning level for models that support reasoning tokens |
+
+## `agent.config.json`
+
+You can put `agent.config.json` either in `~/.minicode/` for user defaults or in a workspace root for project-specific overrides:
+
+```json
+{
+  "modelProvider": "openai-compatible",
+  "model": "zai-org/glm-4.7-flash",
+  "maxSteps": 50,
+  "maxTokens": 4096,
+  "maxContextTokens": 40000,
+  "workspaceRoot": ".",
+  "commandTimeout": 30000,
+  "commandDenylist": [],
+  "confirmDestructive": true,
+  "maxFileSizeBytes": 1000000,
+  "keepRecentMessages": 12,
+  "loopDetectionWindow": 6,
+  "maxToolOutputChars": 8000,
+  "openAiBaseUrl": "http://localhost:1234/v1",
+  "openAiApiKey": "",
+  "enableFileReadDedup": true,
+  "enableAdaptiveKeepRecent": true,
+  "enableToolOutputTruncation": true,
+  "compactionThreshold": 0.8,
+  "compactionModel": ""
+}
+```
+
+### Field mapping
+
+| JSON field | Env var |
+| --- | --- |
+| `modelProvider` | `MODEL_PROVIDER` |
+| `model` | `MODEL` |
+| `maxSteps` | `MAX_STEPS` |
+| `maxTokens` | `MAX_TOKENS` |
+| `maxContextTokens` | `MAX_CONTEXT_TOKENS` |
+| `workspaceRoot` | `WORKSPACE_ROOT` |
+| `commandTimeout` | `COMMAND_TIMEOUT_MS` |
+| `confirmDestructive` | `CONFIRM_DESTRUCTIVE` |
+| `maxFileSizeBytes` | `MAX_FILE_SIZE_BYTES` |
+| `keepRecentMessages` | `KEEP_RECENT_MESSAGES` |
+| `loopDetectionWindow` | `LOOP_DETECTION_WINDOW` |
+| `maxToolOutputChars` | `MAX_TOOL_OUTPUT_CHARS` |
+| `openAiBaseUrl` | `OPENAI_BASE_URL` |
+| `openAiApiKey` | `OPENAI_API_KEY` |
+| `enableFileReadDedup` | `ENABLE_FILE_READ_DEDUP` |
+| `enableAdaptiveKeepRecent` | `ENABLE_ADAPTIVE_KEEP_RECENT` |
+| `enableToolOutputTruncation` | `ENABLE_TOOL_OUTPUT_TRUNCATION` |
+| `compactionThreshold` | `COMPACTION_THRESHOLD` |
+| `compactionModel` | `COMPACTION_MODEL` |
+| `reasoningEffort` | `REASONING_EFFORT` |
+
+`commandDenylist` is JSON-config only. It accepts regex strings that are appended to the built-in destructive-command denylist.
+
+## Tuning for smaller context windows
+
+The context-optimization docs recommend lower `MAX_CONTEXT_TOKENS` values for smaller local models:
+
+| Model context window | Recommended `MAX_CONTEXT_TOKENS` |
+| --- | --- |
+| `8k` | `6000` |
+| `16k` | `12000` |
+| `32k` | `25000` |
+| `64k+` | `40000` to `60000` |
+
+If you are running tighter local models, it is also worth lowering tool output sizes so read-heavy sessions do not dominate the prompt budget.
+
+## Related docs
+
+- [Get Started](/docs/get-started/)
+- [Technical Docs: Context Optimization](/docs/technical/context-optimization/)

--- a/site/content/docs/get-started.md
+++ b/site/content/docs/get-started.md
@@ -1,0 +1,101 @@
+---
+title: Get Started
+description: Install minicode, point it at a model endpoint, and run the CLI or web UI for the first time.
+weight: 10
+kicker: Quick start
+---
+
+`minicode` is a coding agent that can run against local OpenAI-compatible servers such as LM Studio, or against other supported providers depending on how you configure it. The fastest path is to start with a local OpenAI-compatible endpoint, install the CLI globally, and set a small `.env` file in `~/.minicode/`.
+
+## What you need
+
+- Node.js 22+
+- `rg` in your `PATH` for fast search
+- A model endpoint:
+  - LM Studio is the documented happy path in the README
+  - any OpenAI-compatible local server works too
+
+## Quick start with LM Studio
+
+1. Start LM Studio, load a model, and start the local server.
+2. Install minicode globally.
+3. Configure the user-level `.env`.
+
+```bash
+npm install -g @sean.holung/minicode
+
+mkdir -p ~/.minicode
+cat > ~/.minicode/.env << 'EOF'
+MODEL_PROVIDER=openai-compatible
+MODEL=zai-org/glm-4.7-flash
+OPENAI_BASE_URL=http://localhost:1234/v1
+OPENAI_API_KEY=
+MAX_STEPS=50
+MAX_TOKENS=4096
+MAX_CONTEXT_TOKENS=24000
+WORKSPACE_ROOT=.
+COMMAND_TIMEOUT_MS=30000
+MAX_FILE_SIZE_BYTES=1000000
+CONFIRM_DESTRUCTIVE=true
+KEEP_RECENT_MESSAGES=12
+LOOP_DETECTION_WINDOW=6
+EOF
+```
+
+## Run the CLI
+
+Change into the project you want to work on and launch minicode:
+
+```bash
+cd /path/to/your/project
+minicode
+```
+
+You can also start with an initial task:
+
+```bash
+minicode "Add error handling to src/api.ts"
+```
+
+## Start the web UI
+
+Serve mode starts the local web app, the graph-backed API, and the OpenAI-compatible endpoint:
+
+```bash
+minicode serve              # http://localhost:4567
+minicode serve --port 8080
+```
+
+By default you get:
+
+- the web UI at `http://localhost:4567`
+- the OpenAI-compatible API at `http://localhost:4567/v1`
+- a WebSocket connection for live tool and streaming events
+
+## One-shot mode
+
+For scripts, CI, or higher-level orchestration, you can run a single task and exit:
+
+```bash
+minicode --oneshot "Find TODOs and summarize action items"
+minicode -1 "Refactor parseArgs and run tests"
+minicode --oneshot --json "Summarize recent changes"
+minicode --oneshot --out result.txt "Generate release notes"
+```
+
+## Install from source
+
+If you want to work directly from the repository:
+
+```bash
+git clone https://github.com/sean1588/minicode.git
+cd minicode
+npm install
+npm run install:global
+```
+
+## What to read next
+
+- [CLI Reference](/docs/cli-reference/)
+- [Configuration](/docs/configuration/)
+- [Web UI and Serve Mode](/docs/web-ui-and-serve/)

--- a/site/content/docs/plugins-and-extensibility.md
+++ b/site/content/docs/plugins-and-extensibility.md
@@ -1,0 +1,91 @@
+---
+title: Plugins and Extensibility
+description: How the plugin system works today, how to add new language support, and where the runtime SDK is headed.
+weight: 50
+kicker: Extensibility
+---
+
+minicode is built around a plugin-based indexer and a broader runtime architecture that is moving toward a reusable SDK. The plugin system is the main extension point today.
+
+## Built-in language support
+
+The README currently documents built-in support for:
+
+| Language | Extensions | Plugin |
+| --- | --- | --- |
+| TypeScript and JavaScript | `.ts`, `.tsx`, `.js`, `.jsx` | Built-in |
+
+## Installing plugins
+
+There are two supported paths:
+
+### npm package
+
+Install a package that matches the `minicode-plugin-*` naming pattern in the workspace you want minicode to index:
+
+```bash
+npm install minicode-plugin-go
+```
+
+At startup, minicode scans the workspace `package.json` dependencies and devDependencies for packages with that prefix and attempts to load them.
+
+### Local workspace plugin
+
+Place a JavaScript file in:
+
+```text
+<workspace>/.minicode/plugins/
+```
+
+The file should export a `LanguagePlugin` as the default export or a named `plugin`.
+
+## What a plugin provides
+
+Plugins power:
+
+- the compact code map
+- `read_symbol`
+- `find_references`
+- `get_dependencies`
+
+At a minimum, a plugin needs to know how to:
+
+- decide whether it can index a file
+- parse file contents
+- emit `IndexedSymbol` records
+
+Dependency resolution is optional, but it unlocks richer graph-aware tooling.
+
+## `LanguagePlugin` interface
+
+The plugin spec defines a core interface with:
+
+- `name`
+- `extensions`
+- `canIndex(filePath)`
+- `indexFile(filePath, content)`
+- optional `resolveDependencies(symbols, projectFiles)`
+
+The output of `indexFile` is an array of `IndexedSymbol` objects describing names, qualified names, kinds, files, line ranges, signatures, export status, and placeholder dependency arrays.
+
+## What the SDK is aiming for
+
+The draft SDK spec proposes splitting the current app into reusable packages:
+
+- `@minicode/agent-runtime` for the core agent loop
+- `@minicode/tools-core` for default file and command tools
+- `@minicode/indexer` for indexing, graph logic, and plugin support
+- `@minicode/cli` as one consumer of those packages
+
+That direction would make the runtime reusable in:
+
+- custom web apps
+- CI bots
+- IDE integrations
+- agent services that want minicode-style tool orchestration
+
+## Related docs
+
+- [Agent Runtime SDK](/docs/agent-runtime-sdk/)
+- [Technical Docs: Runtime Architecture](/docs/technical/runtime-architecture/)
+- [Technical Docs: Indexing and Graph](/docs/technical/indexing-and-graph/)

--- a/site/content/docs/technical/_index.md
+++ b/site/content/docs/technical/_index.md
@@ -1,0 +1,16 @@
+---
+title: Technical Docs
+description: Architecture notes on the runtime, context management, graph tooling, and the web product direction behind minicode.
+weight: 60
+---
+
+The technical docs are a condensed, reader-friendly layer over the longer architecture notes in the main `minicode` repository.
+
+They cover four themes:
+
+- the product direction behind the web UI and agent-native interface
+- the runtime loop and tool execution model
+- the context-management strategies that keep prompts lean
+- the AST and dependency-graph machinery that powers symbol-aware navigation
+
+These pages are not trying to replace the original engineering notes. They are intended to make the big ideas and system boundaries easier to scan for someone evaluating the project quickly.

--- a/site/content/docs/technical/context-optimization.md
+++ b/site/content/docs/technical/context-optimization.md
@@ -1,0 +1,83 @@
+---
+title: Context Optimization
+description: How minicode keeps long-running coding sessions usable under tighter context budgets.
+weight: 20
+kicker: Technical docs
+---
+
+Context optimization is one of minicode’s original technical wedges. The system is designed to reduce wasted prompt budget, especially for smaller local models, but the same strategies are useful for larger hosted models too.
+
+## Default assumptions
+
+The context-optimization notes describe a few important defaults:
+
+| Parameter | Default | Purpose |
+| --- | --- | --- |
+| `maxContextTokens` | `40,000` | Target budget for session history |
+| `maxToolOutputChars` | `8,000` | Max characters per tool result before truncation |
+| `keepRecentMessages` | `12` | Minimum recent messages protected during trimming |
+
+## How context grows
+
+minicode stores user messages, assistant responses, tool call metadata, and tool outputs in a single session history. That means every retained message competes for space in the next model call.
+
+The practical problem is simple: a handful of large tool outputs can consume a huge fraction of the available context window before the model does any real reasoning.
+
+## Strategies in the runtime
+
+The current implementation uses several layers of control:
+
+### Progressive trimming
+
+When the session exceeds the target budget, older tool results are first shrunk into one-line summaries, then old message chunks are dropped, and only in emergency cases are recent protected messages also shrunk.
+
+### Conversation compaction
+
+Older conversation history can be compacted into a structured summary instead of silently disappearing. This can be mechanical or LLM-based depending on configuration.
+
+### Thinking-trace capping
+
+Intermediate model thinking that accompanies tool calls is capped before it is retained in session state, which cuts repeated low-value reasoning tails out of the prompt history.
+
+### Focus-adaptive code map
+
+The code map is regenerated per step and prioritizes symbols the agent has recently explored, plus their nearby graph neighbors. That keeps the injected structural context relevant as the task evolves.
+
+### Tool output truncation
+
+Large tool outputs are clipped to a configured maximum character count.
+
+In the current CLI config loader, content-aware tool output truncation is enabled by default through `ENABLE_TOOL_OUTPUT_TRUNCATION`.
+
+### Symbol-aware tools
+
+Instead of reading whole files whenever possible, minicode prefers:
+
+- `read_symbol`
+- `find_references`
+- `get_dependencies`
+
+That is the structural side of the context optimization story.
+
+## Additional defaults in the current CLI runtime
+
+The current config loader also enables a few helpful behaviors by default:
+
+- repeated `read_file` deduplication within a turn
+- adaptive reduction of the protected recent-message window as context fills up
+- auto-compaction with a default threshold of `0.8`
+
+Those defaults are worth knowing because some lower-level type comments still reflect older defaults.
+
+## Practical tuning advice
+
+The technical docs recommend lowering `MAX_CONTEXT_TOKENS` for smaller models:
+
+| Context window | Recommended budget |
+| --- | --- |
+| `8k` | `6000` |
+| `16k` | `12000` |
+| `32k` | `25000` |
+| `64k+` | `40000` to `60000` |
+
+For especially tight budgets, it is also worth lowering tool output sizes so file reads do not crowd out the reasoning budget.

--- a/site/content/docs/technical/indexing-and-graph.md
+++ b/site/content/docs/technical/indexing-and-graph.md
@@ -1,0 +1,78 @@
+---
+title: Indexing and Graph
+description: How minicode parses code, builds a dependency graph, and turns that structure into code-map ranking and symbol-aware tools.
+weight: 40
+kicker: Technical docs
+---
+
+The indexing and graph stack is one of the most distinctive parts of minicode. The built-in TypeScript and JavaScript path uses the TypeScript compiler API for fast syntax-level parsing, then builds a dependency graph over the resulting symbols.
+
+## Indexing pipeline
+
+At startup, minicode scans the workspace for supported source files, skips common build and vendor folders, and runs the matching language plugins. The resulting project index stores:
+
+- extracted symbols
+- symbols grouped by file
+- project file contents for dependency resolution
+- directed dependency edges
+- helper APIs such as `getSymbol`, `getDependencyCone`, and `getCodeMap`
+
+## AST parsing strategy
+
+The built-in TypeScript plugin uses `ts.createSourceFile(...)` rather than a full `Program` or type-checking pass. That keeps indexing light and fast while still giving the agent a structural map of declarations.
+
+The plugin walks the tree and extracts:
+
+- functions
+- classes
+- constructors
+- methods
+- interfaces
+- type aliases
+- function-valued variable declarations
+
+Each symbol gets a name, qualified name, kind, file path, line range, signature, and export status.
+
+## Dependency graph construction
+
+After symbol extraction, minicode parses project files again to build edges such as:
+
+| Edge kind | Meaning |
+| --- | --- |
+| `calls` | one symbol invokes another |
+| `references` | one symbol uses another in a type position |
+| `extends` | class inheritance |
+| `implements` | class-to-interface implementation |
+
+The result is a graph that can power dependency-cone traversal and blast-radius analysis.
+
+## Code map ranking
+
+The code map is a compact project skeleton injected into the system prompt. When it needs to be truncated, minicode ranks symbols by:
+
+1. export status
+2. inbound reference count
+3. entry-point bias for index files
+
+In practice, that means high-signal APIs survive context compression more often than random implementation details.
+
+## Tools powered by the graph
+
+The graph is not just for visualization. It directly powers:
+
+- `read_symbol`
+- `find_references`
+- `get_dependencies`
+- `search_code_map`
+
+That is the bridge between indexing internals and day-to-day agent behavior.
+
+## Practical tradeoffs
+
+The technical notes are explicit about the boundaries:
+
+- this is syntax-driven, not full semantic type-checking
+- name-based matching can collide in rare same-name cases
+- the `imports` edge kind exists in shared types but is not yet emitted by the built-in TypeScript resolver
+
+Even with those limits, the system provides much richer structural navigation than plain text search.

--- a/site/content/docs/technical/product-vision.md
+++ b/site/content/docs/technical/product-vision.md
@@ -1,0 +1,54 @@
+---
+title: Product Vision
+description: The web UI and graph view as the clearest expression of minicode’s agent-native interface design.
+weight: 10
+kicker: Technical docs
+---
+
+The `WEB_SERVE_VISION.md` document frames minicode as more than a CLI with a browser wrapper. The core idea is an environment designed around how an agent understands a codebase: symbols, dependencies, focus, and structured navigation.
+
+## The core bet
+
+The vision document makes a few strong claims:
+
+- symbols should be first-class objects in the UI
+- the dependency graph can replace the file tree as the primary navigation surface
+- the agent’s attention should be visible and steerable
+- prompts should become structured workspaces, not just text boxes
+
+That framing is what turns minicode from a utility into a product concept.
+
+## The three layers
+
+The envisioned experience has three coordinated layers:
+
+1. a chat interface for multi-turn work with streaming tool activity
+2. a live view of the agent’s current code map and focus
+3. a human-driven dependency graph for manual exploration
+
+The current web UI already ships meaningful pieces of that stack through `minicode serve`.
+
+## Why the graph matters
+
+The graph is not treated as decoration. In the architecture notes it is the natural UI representation of the same structural model the agent already uses internally.
+
+That matters because the agent does not naturally think in file-tree order. It thinks in:
+
+- which symbol matters now
+- what that symbol depends on
+- which other symbols reference it
+- which focused areas deserve prompt budget
+
+The graph makes that model inspectable.
+
+## Long-term implications
+
+The product vision also opens up richer future workflows:
+
+- symbol attachments in prompts
+- saved workspaces of pinned symbols
+- graph-linked conversations and diffs
+- multi-agent views
+- history replay of the agent’s exploration path
+
+Even when those features are not fully built yet, they help explain why the current web UI already feels different from a standard “chat panel in an IDE” story.

--- a/site/content/docs/technical/runtime-architecture.md
+++ b/site/content/docs/technical/runtime-architecture.md
@@ -1,0 +1,68 @@
+---
+title: Runtime Architecture
+description: The execution loop, session model, tool registry, and model-client abstraction that power a single minicode turn.
+weight: 30
+kicker: Technical docs
+---
+
+The runtime architecture is centered on a tool-using execution loop. A user message enters the session, the model receives the current prompt plus tool schemas, and the agent alternates between model steps and tool execution until it reaches a final answer or a guardrail stops the turn.
+
+## Main components
+
+The runtime docs call out these core pieces:
+
+- `CodingAgent` as the main orchestrator
+- `Session` for all retained message history and trimming behavior
+- `ToolRegistry` for tool schemas and safe execution
+- provider-specific `ModelClient` implementations
+- a system-prompt builder that can inject the code map
+
+## Turn lifecycle
+
+A typical turn looks like this:
+
+1. append the user message to session state
+2. build the tool schemas
+3. build the optional code map
+4. build the system prompt
+5. loop up to `maxSteps`
+6. call the model
+7. if tool calls are returned, execute them and append tool results
+8. if no tool calls are returned, finish with assistant text
+
+This is the core mechanic that makes minicode a runtime rather than a static completion wrapper.
+
+## Tool execution model
+
+The default tool registry includes:
+
+- file tools such as `read_file`, `write_file`, and `edit_file`
+- search and listing tools
+- `run_command`
+- symbol-aware tools when a project index is available
+
+Inputs are validated, tool failures are caught and returned as structured errors, and the agent loop continues from there instead of crashing.
+
+## Guardrails
+
+The runtime includes several hard stops:
+
+- max-step limits
+- loop detection for repeated identical tool calls
+- output truncation for oversized tool results
+- tool-level path and command safety checks
+
+These protections matter because coding agents can otherwise get stuck in repetitive or overly destructive loops.
+
+## Provider abstraction
+
+The runtime supports both Anthropic and OpenAI-compatible paths behind a shared internal `ModelResponse` shape. That keeps the high-level agent behavior stable even when the request/response format changes underneath.
+
+## Why this architecture fits coding work
+
+The runtime notes emphasize a few reasons this shape works well:
+
+- coding tasks often need repeated inspect-edit-run cycles
+- session continuity matters across many tool calls
+- graph-aware tools cut down on wasteful file reads
+- loop and step guards are essential for autonomy without chaos

--- a/site/content/docs/web-ui-and-serve.md
+++ b/site/content/docs/web-ui-and-serve.md
@@ -1,0 +1,144 @@
+---
+title: Web UI and Serve Mode
+description: What ships with `minicode serve`, from the chat UI and sessions to the graph endpoints and OpenAI-compatible API.
+weight: 40
+kicker: Features
+---
+
+`minicode serve` is the browser-facing side of the project. It starts the local chat UI, the OpenAI-compatible API, and the graph-oriented endpoints that power the dependency-graph experience.
+
+## Start serve mode
+
+```bash
+minicode serve
+minicode serve --port 8080
+```
+
+By default this opens:
+
+- the web UI at `http://localhost:4567`
+- the OpenAI-compatible API at `http://localhost:4567/v1`
+- the WebSocket stream at `ws://localhost:4567`
+
+## What the web UI includes
+
+The shipped interface supports:
+
+- streaming text responses
+- compact tool-call pills with elapsed time and expandable results
+- visible intermediate reasoning text
+- full markdown rendering for final responses
+- auto-resize input
+- session save and restore
+- graph view toggle and resizable panes
+
+## Session management
+
+Sessions can be saved and loaded from the UI. Saved sessions live under `~/.minicode/sessions/` and include the active conversation state.
+
+The UI surfaces:
+
+- session labels
+- message counts
+- saved timestamps
+
+## OpenAI-compatible API
+
+Serve mode exposes a standard chat-completions surface so other clients can talk to minicode as if it were a model:
+
+```bash
+curl http://localhost:4567/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"minicode-agent","messages":[{"role":"user","content":"list files"}]}'
+```
+
+The API also supports streaming and `GET /v1/models`.
+
+## REST endpoints
+
+The serve-mode feature guide documents these main groups of endpoints:
+
+### Agent and session endpoints
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/api/status` | Agent status, workspace, model, provider |
+| `GET` | `/api/models` | List models when the provider supports model enumeration |
+| `POST` | `/api/model` | Switch the active model |
+| `GET` | `/api/config` | Formatted agent configuration |
+| `POST` | `/api/chat` | Send a message and get a non-streaming response |
+| `GET` | `/api/sessions` | List saved sessions |
+| `POST` | `/api/sessions/save` | Save current session |
+| `POST` | `/api/sessions/load` | Load a saved session |
+
+### Graph and symbol endpoints
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/api/symbols` | All indexed symbols |
+| `GET` | `/api/symbols/:name/dependencies` | Dependency cone for a symbol |
+| `GET` | `/api/symbols/:name/references` | Referring symbols |
+| `GET` | `/api/symbols/:name/source` | Extracted source for a symbol |
+| `GET` | `/api/code-map` | Ranked code map |
+| `GET` | `/api/graph` | Full dependency graph |
+| `GET` | `/api/focus` | Pinned symbols |
+| `POST` | `/api/focus` | Pin or unpin a symbol |
+
+### Annotation and explain endpoints
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/api/annotations` | All annotations for the active session |
+| `GET` | `/api/symbols/:name/annotations` | Notes for a specific symbol |
+| `POST` | `/api/symbols/:name/annotations` | Add a note to a symbol |
+| `DELETE` | `/api/symbols/:name/annotations/:index` | Remove a note by index |
+| `DELETE` | `/api/symbols/:name/annotations` | Clear all notes for a symbol |
+| `GET` | `/api/symbols/:name/explain` | SSE stream for symbol explanation |
+
+## Graph UI capabilities
+
+The current graph experience includes:
+
+- search and ranked symbol lookup
+- double-click expansion of 1-hop neighbors
+- hover highlighting
+- node detail panels
+- focus pinning
+- graph fit, re-layout, and clear actions
+- agent activity pulses when symbol-aware tools run
+
+## Symbol annotations and explain
+
+The web UI also supports symbol-level notes and an `Explain` flow:
+
+- annotations attach user notes to specific symbols
+- those notes are injected only when relevant tools touch the symbol
+- the explain flow runs a separate research pass for a symbol without polluting the main chat context
+
+## WebSocket protocol
+
+The WebSocket channel supports:
+
+### Client messages
+
+- `chat`
+- `cancel`
+- `switch_model`
+
+### Server messages
+
+- `turn_start`
+- `thinking`
+- `streaming_chunk`
+- `step`
+- `tool_call_start`
+- `tool_call_end`
+- `turn_end`
+- `error`
+- `busy`
+- `model_changed`
+
+## Related docs
+
+- [Technical Docs: Product Vision](/docs/technical/product-vision/)
+- [Technical Docs: Indexing and Graph](/docs/technical/indexing-and-graph/)

--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -50,6 +50,69 @@
         margin: 0 auto;
         padding: 0 1rem 4rem;
       }
+      .site-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        margin-bottom: 2.2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid rgba(147, 167, 224, 0.12);
+      }
+      .site-brand {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.7rem;
+        color: var(--text);
+        font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+        font-size: 0.88rem;
+        font-weight: 700;
+        letter-spacing: 0.14em;
+        text-decoration: none;
+        text-transform: uppercase;
+      }
+      .site-brand-mark {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 2rem;
+        height: 2rem;
+        border-radius: 999px;
+        background: rgba(138, 166, 255, 0.16);
+        border: 1px solid rgba(138, 166, 255, 0.22);
+        color: var(--accent-strong);
+      }
+      .site-nav {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 0.55rem;
+      }
+      .site-nav a {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 2.35rem;
+        padding: 0.55rem 0.9rem;
+        border-radius: 999px;
+        border: 1px solid rgba(138, 166, 255, 0.12);
+        background: rgba(20, 26, 42, 0.48);
+        color: var(--muted);
+        font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+        font-size: 0.77rem;
+        letter-spacing: 0.08em;
+        text-decoration: none;
+        text-transform: uppercase;
+        transition: border-color 150ms ease, background 150ms ease, color 150ms ease, transform 150ms ease;
+      }
+      .site-nav a:hover,
+      .site-nav a.active {
+        transform: translateY(-1px);
+        border-color: rgba(138, 166, 255, 0.28);
+        background: rgba(138, 166, 255, 0.12);
+        color: var(--text);
+      }
       .card {
         background: var(--card);
         border: 1px solid var(--border);
@@ -316,11 +379,229 @@
         padding: 0.9rem;
         border-radius: 24px;
       }
+      .screenshot-link {
+        display: block;
+      }
+      .screenshot-link:hover img {
+        border-color: rgba(138, 166, 255, 0.28);
+      }
       .app-showcase .screenshot-frame img {
         border-radius: 18px;
       }
       .app-showcase .panel-caption {
         max-width: 56rem;
+      }
+      .faq-shell {
+        padding: 1.6rem;
+      }
+      .faq-list {
+        display: grid;
+        gap: 0.9rem;
+      }
+      .faq-item {
+        border-radius: 22px;
+        border: 1px solid rgba(138, 166, 255, 0.14);
+        background: rgba(11, 15, 28, 0.68);
+        overflow: hidden;
+      }
+      .faq-item summary {
+        cursor: pointer;
+        list-style: none;
+        padding: 1rem 1.15rem;
+        color: var(--text);
+        font-size: 1.06rem;
+        font-weight: 700;
+        line-height: 1.35;
+      }
+      .faq-item summary::-webkit-details-marker {
+        display: none;
+      }
+      .faq-item summary::after {
+        content: "+";
+        float: right;
+        color: var(--accent);
+        font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+        font-size: 1rem;
+        margin-left: 1rem;
+      }
+      .faq-item[open] summary::after {
+        content: "−";
+      }
+      .faq-item p {
+        margin: 0;
+        padding: 0 1.15rem 1rem;
+      }
+      .faq-item p + p {
+        padding-top: 0.15rem;
+      }
+      .docs-shell {
+        display: grid;
+        grid-template-columns: minmax(16rem, 18rem) minmax(0, 1fr);
+        gap: 2rem;
+        align-items: start;
+      }
+      .docs-sidebar {
+        position: sticky;
+        top: 1.5rem;
+        align-self: start;
+      }
+      .docs-sidebar-nav {
+        display: grid;
+        gap: 0.45rem;
+      }
+      .docs-sidebar-heading {
+        margin: 1rem 0 0.35rem;
+        color: var(--accent);
+        font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+        font-size: 0.74rem;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .docs-sidebar-link {
+        display: block;
+        padding: 0.7rem 0.85rem;
+        border-radius: 16px;
+        border: 1px solid rgba(138, 166, 255, 0.08);
+        background: rgba(20, 26, 42, 0.38);
+        color: var(--muted);
+        font-size: 0.95rem;
+        line-height: 1.35;
+        text-decoration: none;
+        transition: border-color 150ms ease, background 150ms ease, color 150ms ease;
+      }
+      .docs-sidebar-link:hover,
+      .docs-sidebar-link.active {
+        border-color: rgba(138, 166, 255, 0.28);
+        background: rgba(138, 166, 255, 0.1);
+        color: var(--text);
+      }
+      .docs-content {
+        min-width: 0;
+      }
+      .docs-heading {
+        margin-bottom: 2rem;
+      }
+      .docs-lead {
+        max-width: 48rem;
+      }
+      .docs-card-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 1rem;
+        margin-top: 1.75rem;
+      }
+      .docs-card {
+        display: block;
+        padding: 1.2rem;
+        border-radius: 22px;
+        border: 1px solid rgba(138, 166, 255, 0.12);
+        background: linear-gradient(180deg, rgba(20, 26, 42, 0.96), rgba(12, 16, 30, 0.98));
+        color: var(--text);
+        text-decoration: none;
+        box-shadow: 0 20px 46px rgba(0, 0, 0, 0.18);
+        transition: transform 150ms ease, border-color 150ms ease;
+      }
+      .docs-card:hover {
+        transform: translateY(-1px);
+        border-color: rgba(138, 166, 255, 0.28);
+      }
+      .docs-card p {
+        margin: 0.55rem 0 0;
+      }
+      .docs-card-meta {
+        display: inline-block;
+        margin-bottom: 0.7rem;
+        color: var(--accent);
+        font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+        font-size: 0.72rem;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+      }
+      .prose {
+        display: grid;
+        gap: 1.35rem;
+      }
+      .prose > :first-child {
+        margin-top: 0;
+      }
+      .prose h2,
+      .prose h3,
+      .prose h4 {
+        color: var(--text);
+      }
+      .prose h2 {
+        margin-top: 0.8rem;
+        font-size: clamp(1.7rem, 3vw, 2.35rem);
+      }
+      .prose h3 {
+        margin-top: 0.4rem;
+        font-size: 1.32rem;
+      }
+      .prose h4 {
+        font-size: 1.05rem;
+        letter-spacing: -0.02em;
+      }
+      .prose p,
+      .prose li {
+        color: var(--muted);
+        font-size: 1rem;
+      }
+      .prose ul,
+      .prose ol {
+        display: grid;
+        gap: 0.55rem;
+        padding-left: 1.25rem;
+      }
+      .prose table {
+        width: 100%;
+        border-collapse: collapse;
+        overflow: hidden;
+        border-radius: 18px;
+        border: 1px solid rgba(138, 166, 255, 0.12);
+        background: rgba(12, 16, 30, 0.92);
+      }
+      .prose th,
+      .prose td {
+        padding: 0.8rem 0.9rem;
+        text-align: left;
+        vertical-align: top;
+        border-bottom: 1px solid rgba(138, 166, 255, 0.08);
+      }
+      .prose th {
+        color: var(--text);
+        font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+        font-size: 0.8rem;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        background: rgba(20, 26, 42, 0.96);
+      }
+      .prose tr:last-child td {
+        border-bottom: 0;
+      }
+      .prose code {
+        font-size: 0.95em;
+      }
+      .prose pre {
+        margin: 0;
+        padding: 1rem 1.1rem;
+        overflow: auto;
+        border-radius: 20px;
+        border: 1px solid rgba(138, 166, 255, 0.12);
+        background: rgba(6, 10, 19, 0.96);
+      }
+      .prose pre code {
+        display: block;
+        padding: 0;
+        background: transparent;
+        border-radius: 0;
+      }
+      .prose blockquote {
+        margin: 0;
+        padding: 0.9rem 1rem;
+        border-left: 3px solid rgba(138, 166, 255, 0.36);
+        border-radius: 0 16px 16px 0;
+        background: rgba(138, 166, 255, 0.08);
       }
       ul {
         color: var(--muted);
@@ -436,6 +717,17 @@
         border-radius: 6px;
         background: rgba(138, 166, 255, 0.16);
       }
+      @media (max-width: 1000px) {
+        .docs-shell {
+          grid-template-columns: 1fr;
+        }
+        .docs-sidebar {
+          position: static;
+        }
+        .docs-card-grid {
+          grid-template-columns: 1fr;
+        }
+      }
       @media (max-width: 900px) {
         .hero,
         .steps,
@@ -446,6 +738,14 @@
         }
       }
       @media (max-width: 760px) {
+        .site-header {
+          align-items: flex-start;
+          flex-direction: column;
+        }
+        .site-nav {
+          width: 100%;
+          justify-content: flex-start;
+        }
         .card {
           padding: 1.2rem;
           border-radius: 24px;
@@ -482,6 +782,17 @@
   <body>
     <main>
       <div class="card">
+        <header class="site-header">
+          <a class="site-brand" href="/">
+            <span class="site-brand-mark">m</span>
+            <span>minicode</span>
+          </a>
+          <nav class="site-nav" aria-label="Primary">
+            <a class="{{ if .IsHome }}active{{ end }}" href="/">Overview</a>
+            <a class="{{ if eq .Section "docs" }}active{{ end }}" href="/docs/">Docs</a>
+            <a href="https://github.com/sean1588/minicode">GitHub</a>
+          </nav>
+        </header>
         {{ block "main" . }}{{ end }}
       </div>
     </main>

--- a/site/layouts/docs/list.html
+++ b/site/layouts/docs/list.html
@@ -1,0 +1,39 @@
+{{ define "main" }}
+  <div class="docs-shell">
+    <aside class="docs-sidebar">
+      {{ partial "docs-sidebar.html" . }}
+    </aside>
+    <section class="docs-content">
+      <div class="docs-heading">
+        <div class="eyebrow">Docs</div>
+        <h1>{{ .Title }}</h1>
+        {{ with .Params.description }}<p class="hero-copy docs-lead">{{ . }}</p>{{ end }}
+      </div>
+
+      {{ with .Content }}
+        <div class="prose">
+          {{ . }}
+        </div>
+      {{ end }}
+
+      {{ if or (.Sections) (.RegularPages) }}
+        <div class="docs-card-grid">
+          {{ range .RegularPages.ByWeight }}
+            <a class="docs-card" href="{{ .RelPermalink }}">
+              <span class="docs-card-meta">{{ with .Params.kicker }}{{ . }}{{ else }}Docs page{{ end }}</span>
+              <h3>{{ .Title }}</h3>
+              {{ with .Params.description }}<p>{{ . }}</p>{{ end }}
+            </a>
+          {{ end }}
+          {{ range .Sections.ByWeight }}
+            <a class="docs-card" href="{{ .RelPermalink }}">
+              <span class="docs-card-meta">Section</span>
+              <h3>{{ .Title }}</h3>
+              {{ with .Params.description }}<p>{{ . }}</p>{{ end }}
+            </a>
+          {{ end }}
+        </div>
+      {{ end }}
+    </section>
+  </div>
+{{ end }}

--- a/site/layouts/docs/single.html
+++ b/site/layouts/docs/single.html
@@ -1,0 +1,17 @@
+{{ define "main" }}
+  <div class="docs-shell">
+    <aside class="docs-sidebar">
+      {{ partial "docs-sidebar.html" . }}
+    </aside>
+    <article class="docs-content">
+      <div class="docs-heading">
+        <div class="eyebrow">{{ with .Parent }}{{ .Title }}{{ else }}Docs{{ end }}</div>
+        <h1>{{ .Title }}</h1>
+        {{ with .Params.description }}<p class="hero-copy docs-lead">{{ . }}</p>{{ end }}
+      </div>
+      <div class="prose">
+        {{ .Content }}
+      </div>
+    </article>
+  </div>
+{{ end }}

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -30,12 +30,14 @@
         <div class="panel-dots" aria-hidden="true"><span></span><span></span><span></span></div>
       </div>
       <div class="screenshot-frame">
-        <img
-          src="/images/minicode-ui.webp"
-          alt="minicode web UI showing chat activity, dependency graph, and symbol detail panel"
-          width="1723"
-          height="920"
-        />
+        <a class="screenshot-link" href="/images/minicode-ui.webp" target="_blank" rel="noreferrer">
+          <img
+            src="/images/minicode-ui.webp"
+            alt="minicode web UI showing chat activity, dependency graph, and symbol detail panel"
+            width="1723"
+            height="920"
+          />
+        </a>
       </div>
       <p class="panel-caption">The web UI makes the core idea visible: chat, tool activity, symbol graph, and focused code exploration all in the same surface.</p>
       <div class="panel-meta">
@@ -50,7 +52,7 @@
     <div class="section-intro">
       <div class="eyebrow">Product surface</div>
       <h2>More than a single interface</h2>
-      <p>minicode now reads less like a single tool and more like a compact agent platform: a graph-native web app, a coding runtime, an OpenAI-compatible endpoint, and extensible language-aware indexing.</p>
+      <p>minicode now reads less like a single tool and more like a compact agent platform: a graph-native web app, a coding runtime, an OpenAI-compatible endpoint, and extensible language-aware indexing. Today the deepest built-in indexing path is focused on TypeScript and JavaScript, with plugins leaving room to add more languages over time.</p>
     </div>
     <div class="grid three-up compact-cards">
       <article>
@@ -157,7 +159,7 @@
       </article>
       <article>
         <h3>Extensible by design</h3>
-        <p>Language plugins, graph-aware tools, and an SDK direction that lets the runtime become a reusable foundation.</p>
+        <p>Today the built-in path goes deepest on TypeScript and JavaScript, with language plugins, graph-aware tools, and an SDK direction that leave room to grow language coverage over time.</p>
         <div class="card-note">runtime + plugin ecosystem</div>
       </article>
     </div>
@@ -189,15 +191,42 @@
     </div>
   </section>
 
+  <section class="section-shell faq-shell">
+    <div class="section-intro">
+      <div class="eyebrow">FAQ</div>
+      <h2>Questions technical readers usually ask first</h2>
+      <p>minicode has a pretty opinionated architecture, so it helps to answer the common comparison questions directly.</p>
+    </div>
+    <div class="faq-list">
+      <details class="faq-item" open>
+        <summary>Why did minicode use AST parsing instead of connecting to the TypeScript LSP?</summary>
+        <p>Because the goal was not just editor intelligence. minicode needed a lightweight, portable way to extract symbols, signatures, and dependency edges that could be injected into agent context, cached, and reused inside graph-aware tools. Using the TypeScript compiler AST keeps the indexing path syntax-driven and self-contained, without requiring an external language server process or editor integration layer.</p>
+        <p>The tradeoff is that this is not trying to replace everything an LSP does. LSPs are great for editor workflows like completions, diagnostics, and refactors. minicode is more focused on the agent-runtime side: compact structural context, symbol-aware retrieval, and dependency-cone navigation.</p>
+        <p>That built-in indexing path is currently focused on TypeScript and JavaScript. The broader language story is plugin-based on purpose, so the architecture can grow beyond the initial languages without pretending the core ships equally deep support for everything today.</p>
+      </details>
+      <details class="faq-item">
+        <summary>How is this different from aider?</summary>
+        <p>aider is centered more around file-oriented coding assistance, prompts, and git-driven edit workflows. minicode overlaps with that general category, but the core thesis is different: it is built around structural context optimization, symbol-level tooling, and a graph-native interface that exposes how the agent is traversing code.</p>
+        <p>So the distinction is less about “better or worse” and more about emphasis. aider is strong as a practical editing assistant. minicode is more explicitly an experiment in giving coding agents a structural model of the codebase instead of mostly operating at the file level.</p>
+      </details>
+      <details class="faq-item">
+        <summary>How is this different from a tree-sitter-first approach?</summary>
+        <p>tree-sitter is excellent for fast, broad syntax parsing across many languages. minicode took a narrower path for TypeScript and JavaScript by using the TypeScript compiler AST to build a project symbol graph and power tools like <code>read_symbol</code>, <code>find_references</code>, and <code>get_dependencies</code>.</p>
+        <p>The tradeoff is less breadth today in exchange for richer language-specific structural navigation. For this project, depth on the primary language mattered more than broad generic parsing.</p>
+      </details>
+      <details class="faq-item">
+        <summary>Why does any of this matter if frontier models already have large context windows?</summary>
+        <p>Because larger context windows do not make irrelevant context free. Even when a model can fit more code, bloated prompts still cost latency, money, and attention. minicode is built around improving signal density, not just compressing token counts for the sake of it.</p>
+        <p>The local-model origin makes the problem easier to see, but the same tradeoff shows up with hosted models too: less wasted context usually means a tighter working set for the task that actually matters.</p>
+      </details>
+    </div>
+  </section>
+
   <section class="cta-panel">
     <h2>Read less. Reason better. Use fewer tokens.</h2>
     <p>minicode is built on a simple bet: coding models perform better when you give them less context, but better context.</p>
     <div class="hero-actions">
-      <a class="button primary" href="https://github.com/sean1588/minicode">Get started</a>
-      <a class="button secondary" href="https://github.com/sean1588/minicode-site">Site repo</a>
-    </div>
-    <div class="footer">
-      Static site powered by <code>Hugo</code>, deployed via <code>Pulumi</code> to private <code>S3</code> + <code>CloudFront</code>.
+      <a class="button primary" href="/docs/get-started/">Get started</a>
     </div>
   </section>
 {{ end }}

--- a/site/layouts/partials/docs-sidebar.html
+++ b/site/layouts/partials/docs-sidebar.html
@@ -1,0 +1,17 @@
+{{ $current := . }}
+{{ with site.GetPage "/docs" }}
+  <nav class="docs-sidebar-nav" aria-label="Documentation">
+    <div class="docs-sidebar-heading">Start here</div>
+    <a class="docs-sidebar-link{{ if eq $current.RelPermalink .RelPermalink }} active{{ end }}" href="{{ .RelPermalink }}">Documentation overview</a>
+    {{ range .RegularPages.ByWeight }}
+      <a class="docs-sidebar-link{{ if eq $current.RelPermalink .RelPermalink }} active{{ end }}" href="{{ .RelPermalink }}">{{ .Title }}</a>
+    {{ end }}
+    {{ range .Sections.ByWeight }}
+      <div class="docs-sidebar-heading">{{ .Title }}</div>
+      <a class="docs-sidebar-link{{ if eq $current.RelPermalink .RelPermalink }} active{{ end }}" href="{{ .RelPermalink }}">{{ .Title }} overview</a>
+      {{ range .RegularPages.ByWeight }}
+        <a class="docs-sidebar-link{{ if eq $current.RelPermalink .RelPermalink }} active{{ end }}" href="{{ .RelPermalink }}">{{ .Title }}</a>
+      {{ end }}
+    {{ end }}
+  </nav>
+{{ end }}


### PR DESCRIPTION
## Summary
- add a first-pass docs site under `/docs` with a left nav and dedicated docs layouts
- add foundational docs based on the `minicode` README, `docs/`, and `packages/agent-sdk/README.md`
- refine the landing page by linking the CTA to `Get Started`, making the app screenshot open full-size, adding an FAQ, and clarifying that deep built-in indexing currently focuses on TypeScript/JavaScript while leaving room for language plugins

## Notes
- docs content was fact-checked against the current `minicode` implementation, not just the prose docs
- `hugo` builds cleanly locally
