### PR TITLE
[codex] Fix pretty URL routing for docs pages

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -60,6 +60,32 @@ const oac = new aws.cloudfront.OriginAccessControl("site-oac", {
   signingProtocol: "sigv4",
 });
 
+const prettyUrlRewriter = new aws.cloudfront.Function("site-pretty-url-rewriter", {
+  name: `${siteName}-pretty-url-rewriter`,
+  runtime: "cloudfront-js-2.0",
+  comment: "Rewrites directory-style paths to index.html for static-site routing",
+  publish: true,
+  code: `function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+
+  if (uri === "/") {
+    return request;
+  }
+
+  if (uri.endsWith("/")) {
+    request.uri = uri + "index.html";
+    return request;
+  }
+
+  if (!uri.includes(".")) {
+    request.uri = uri + "/index.html";
+  }
+
+  return request;
+}`,
+});
+
 const existingCertificateArn = configuredCertificateArn
   ? validateCloudFrontCertificateArn(configuredCertificateArn)
   : undefined;
@@ -128,6 +154,12 @@ const cdn = new aws.cloudfront.Distribution("site-cdn", {
     cachedMethods: ["GET", "HEAD"],
     compress: true,
     cachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
+    functionAssociations: [
+      {
+        eventType: "viewer-request",
+        functionArn: prettyUrlRewriter.arn,
+      },
+    ],
   },
   customErrorResponses: [
     {


### PR DESCRIPTION
## Summary
- add a CloudFront Function that rewrites directory-style pretty URLs to `index.html` object keys before requests hit the private S3 origin
- attach the function to the default cache behavior so routes like `/docs/` and `/docs/get-started/` resolve to the generated Hugo files instead of falling through to the root page

## Root Cause
The site is served from a private S3 bucket behind CloudFront using the S3 bucket endpoint, not S3 website hosting. Requests such as `/docs/` do not automatically resolve to `docs/index.html` at that origin, so S3 returns 403 and CloudFront's custom error response rewrites those misses back to `/index.html`.

That makes internal navigation look broken even though the generated files exist and the HTML links are correct.

## Validation
- confirmed the generated site contains `site/public/docs/index.html` and `site/public/docs/get-started/index.html`
- confirmed the live site currently returns the homepage HTML for `/docs/` and `/docs/get-started/`
- verified the infrastructure package compiles with TypeScript using Node 22 (`"/mnt/c/Program Files/nodejs/node.exe" ./node_modules/typescript/bin/tsc -p .`)
