### PR TITLE
Refresh site docs for MCP and new web features

### DIFF
--- a/site/content/docs/_index.md
+++ b/site/content/docs/_index.md
@@ -1,17 +1,18 @@
 ---
 title: Documentation
-description: A first-pass reference for getting started with minicode, understanding the CLI and config, and digging into the runtime and graph-oriented architecture.
+description: A practical reference for getting started with minicode, understanding the CLI, MCP server, config surface, and digging into the runtime and graph-oriented architecture.
 weight: 1
 ---
 
-minicode started as a way to make smaller local models more effective for coding work, then expanded into a broader agent runtime with a graph-native web UI and an OpenAI-compatible server mode. The docs here are a curated first pass built from the main `README.md` and the existing technical documents in the core repository.
+minicode started as a way to make smaller local models more effective for coding work, then expanded into a broader agent runtime with a graph-native web UI, structural analysis tooling, an MCP server, and an OpenAI-compatible serve mode. The docs here are a curated reference built from the main `README.md`, the technical documents in the core repository, and the current shipped behavior in the codebase.
 
 Use this section to:
 
 - get a local setup running quickly
 - learn the main CLI and serve-mode workflows
+- connect Claude Code or another external client through the MCP server
 - configure the agent for local or hosted backends
-- understand the runtime, context management, and graph-aware tooling
+- understand the runtime, context management, graph-aware tooling, and structural analysis
 - explore the plugin and SDK direction
 
 The current information architecture is intentionally simple. We can reshape the categories later once the docs footprint grows.

--- a/site/content/docs/cli-reference.md
+++ b/site/content/docs/cli-reference.md
@@ -9,6 +9,7 @@ The CLI has three primary modes:
 
 - interactive terminal use
 - serve mode for the web UI and OpenAI-compatible backend
+- plugin install for Claude Code / MCP setup
 - one-shot mode for scripting and automation
 
 ## Interactive usage
@@ -38,11 +39,24 @@ minicode serve --port 8080
 This mode exposes:
 
 - the web chat UI
+- the MCP endpoint
 - session management
+- settings and persisted non-secret config editing
+- structural analysis and AI explanations in the graph UI
 - graph and symbol endpoints
 - the OpenAI-compatible `/v1/chat/completions` API
 
 It is mutually exclusive with `--oneshot`, `--json`, and `--out`.
+
+## Claude Code plugin install
+
+Install the bundled Claude Code plugin globally:
+
+```bash
+minicode plugin install
+```
+
+This creates a symlink under `~/.claude/plugins/minicode` pointing at the plugin bundled with the `minicode` package. The plugin expects `minicode serve` to be running so it can reach the MCP endpoint at `http://localhost:4567/mcp`.
 
 ## One-shot mode
 
@@ -83,6 +97,12 @@ The interactive CLI also exposes built-in slash commands:
 | --- | --- |
 | `/help` | Show the available commands |
 | `/config` | Print the active runtime configuration |
+| `/config keys` | List editable persisted config keys |
+| `/config get <key>` | Show the effective, workspace, global, and env-layer values for one key |
+| `/config set <key> <value>` | Save a workspace-scoped persisted value |
+| `/config set <key> <value> --global` | Save a user-level persisted value in `~/.minicode/agent.config.json` |
+| `/config unset <key>` | Remove a workspace-scoped persisted value |
+| `/config unset <key> --global` | Remove a user-level persisted value |
 | `/compact` | Compact older session history |
 | `/reasoning [level]` | View or change reasoning effort |
 | `/models` | List provider models when model listing is supported |
@@ -131,3 +151,4 @@ If you are working on minicode itself, the repository exposes these scripts:
 - [Get Started](/docs/get-started/)
 - [Configuration](/docs/configuration/)
 - [Web UI and Serve Mode](/docs/web-ui-and-serve/)
+- [MCP Server](/docs/mcp-server/)

--- a/site/content/docs/configuration.md
+++ b/site/content/docs/configuration.md
@@ -7,6 +7,13 @@ kicker: Reference
 
 minicode keeps its configuration and cache outside your project directory. That lets you reuse the same setup across workspaces while keeping project roots clean.
 
+Non-secret settings can now also be edited from:
+
+- the web UI `Settings` modal in `minicode serve`
+- the CLI slash commands: `/config keys|get|set|unset`
+
+Secrets like API keys still remain env-only for now.
+
 ## Configuration precedence
 
 Later sources override earlier ones:
@@ -44,6 +51,7 @@ The cache lives under `~/.minicode/cache/<workspace-hash>/`.
 | `COMPACTION_THRESHOLD` | `0.8` | Auto-compaction threshold as a fraction of context fullness |
 | `COMPACTION_MODEL` | none | Optional model used for LLM-based compaction |
 | `REASONING_EFFORT` | none | Optional reasoning level for models that support reasoning tokens |
+| `ENABLE_DYNAMIC_PROMPT` | `true` | Rebuild the project-aware system prompt every step; disabling it can improve KV-cache reuse at the cost of a less adaptive code map |
 
 ## `agent.config.json`
 
@@ -70,7 +78,9 @@ You can put `agent.config.json` either in `~/.minicode/` for user defaults or in
   "enableAdaptiveKeepRecent": true,
   "enableToolOutputTruncation": true,
   "compactionThreshold": 0.8,
-  "compactionModel": ""
+  "compactionModel": "",
+  "reasoningEffort": "medium",
+  "enableDynamicPrompt": true
 }
 ```
 
@@ -98,8 +108,38 @@ You can put `agent.config.json` either in `~/.minicode/` for user defaults or in
 | `compactionThreshold` | `COMPACTION_THRESHOLD` |
 | `compactionModel` | `COMPACTION_MODEL` |
 | `reasoningEffort` | `REASONING_EFFORT` |
+| `enableDynamicPrompt` | `ENABLE_DYNAMIC_PROMPT` |
 
 `commandDenylist` is JSON-config only. It accepts regex strings that are appended to the built-in destructive-command denylist.
+
+## Editing persisted config from the UI or CLI
+
+The editable config surface is intentionally limited to non-secret runtime defaults. Today that includes fields like:
+
+- model provider and default model
+- token and step limits
+- timeout and file-size limits
+- prompt and compaction behavior
+- reasoning effort and dynamic-prompt behavior
+
+From the CLI:
+
+```bash
+/config keys
+/config get model
+/config set model anthropic/claude-sonnet-4-5
+/config set maxContextTokens 24000 --global
+/config unset reasoningEffort
+```
+
+From the web UI:
+
+- click `Settings`
+- choose workspace or global scope
+- edit persisted values
+- save and restart `minicode` to apply them to new sessions
+
+Environment variables still win over persisted values, and the UI shows when an env var is overriding a saved setting.
 
 ## Tuning for smaller context windows
 

--- a/site/content/docs/get-started.md
+++ b/site/content/docs/get-started.md
@@ -59,7 +59,7 @@ minicode "Add error handling to src/api.ts"
 
 ## Start the web UI
 
-Serve mode starts the local web app, the graph-backed API, and the OpenAI-compatible endpoint:
+Serve mode starts the local web app, the graph-backed API, the structural-analysis surface, the MCP endpoint, and the OpenAI-compatible endpoint:
 
 ```bash
 minicode serve              # http://localhost:4567
@@ -70,7 +70,32 @@ By default you get:
 
 - the web UI at `http://localhost:4567`
 - the OpenAI-compatible API at `http://localhost:4567/v1`
+- the MCP endpoint at `http://localhost:4567/mcp`
 - a WebSocket connection for live tool and streaming events
+
+## Use it with Claude Code via MCP
+
+If you want the same symbol-aware tools inside Claude Code, start `minicode serve` and then install the bundled plugin:
+
+```bash
+minicode plugin install
+```
+
+That creates the global Claude plugin symlink under `~/.claude/plugins/minicode` and points it at the MCP server exposed by `minicode serve`.
+
+The plugin is built around the MCP tools and resources shipped by minicode:
+
+- `read_symbol`
+- `find_references`
+- `get_dependencies`
+- `search_code_map`
+- `find_path`
+- `add_annotation`
+- `list_annotations`
+- `minicode://code-map`
+- `minicode://structural-analysis`
+
+Once the plugin is installed, Claude Code can use minicode's AST-backed tools while the web UI still shows live graph activity and structural analysis for the same workspace.
 
 ## One-shot mode
 
@@ -99,3 +124,4 @@ npm run install:global
 - [CLI Reference](/docs/cli-reference/)
 - [Configuration](/docs/configuration/)
 - [Web UI and Serve Mode](/docs/web-ui-and-serve/)
+- [MCP Server](/docs/mcp-server/)

--- a/site/content/docs/mcp-server.md
+++ b/site/content/docs/mcp-server.md
@@ -1,0 +1,128 @@
+---
+title: MCP Server
+description: Connect external agents such as Claude Code to minicode's symbol-aware tools, code-map resources, and structural analysis.
+weight: 45
+kicker: Integration
+---
+
+`minicode serve` now exposes a built-in MCP (Model Context Protocol) server. That lets external agents use the same indexed code-intelligence surface that powers the web UI: symbol-aware tools, graph-backed navigation, annotations, and structural-analysis resources.
+
+This is the easiest way to reuse minicode's AST-backed project understanding outside the native UI.
+
+## What it gives you
+
+The MCP server is designed for the cases where a generic coding agent would otherwise fall back to file reads and text search.
+
+With minicode behind MCP, an external client can:
+
+- read a symbol directly instead of dumping a whole file
+- trace references and dependency cones through the indexed graph
+- search the code map by symbol name
+- inspect deterministic structural-analysis findings
+- attach and read symbol annotations
+
+If the web UI is open at the same time, you can also watch that exploration live in the dependency graph.
+
+## Start the server
+
+The MCP endpoint is hosted by `minicode serve`:
+
+```bash
+minicode serve
+```
+
+By default that starts:
+
+- web UI: `http://localhost:4567`
+- OpenAI-compatible API: `http://localhost:4567/v1`
+- MCP endpoint: `http://localhost:4567/mcp`
+
+## Install the Claude Code plugin
+
+The repository ships a bundled Claude Code plugin, so the quickest integration path is:
+
+```bash
+minicode plugin install
+```
+
+That command:
+
+- creates `~/.claude/plugins/minicode`
+- symlinks it to the plugin bundled with the installed `minicode` package
+- configures Claude Code to talk to `http://localhost:4567/mcp` by default
+
+After that, keep `minicode serve` running and open Claude Code in the workspace you want to explore.
+
+## MCP tools
+
+The current MCP server exposes these primary tools:
+
+| Tool | Purpose |
+| --- | --- |
+| `read_symbol` | Read one function, class, interface, or type with source, signature, dependencies, references, and annotations |
+| `find_references` | Find what calls or references a symbol |
+| `get_dependencies` | Walk the dependency cone for a symbol |
+| `search_code_map` | Search indexed symbols by name or substring |
+| `find_path` | Find the shortest graph path between two symbols or trace to an entry point |
+| `add_annotation` | Attach a user note to a symbol |
+| `list_annotations` | List annotations for one symbol or the whole session |
+
+For TypeScript and JavaScript work, `read_symbol` and `search_code_map` are usually much higher-signal than generic file reads.
+
+## MCP resources
+
+The server also exposes two high-value resources:
+
+| Resource | Purpose |
+| --- | --- |
+| `minicode://code-map` | Ranked project skeleton showing indexed symbols and signatures |
+| `minicode://structural-analysis` | Deterministic findings for cycles, hotspots, fan-out, and coupling |
+
+These are useful when you want a broad picture before drilling into individual symbols.
+
+## Claude plugin behavior
+
+The bundled Claude plugin includes opinionated skill prompts for the most common workflows:
+
+- `symbols` for symbol lookup
+- `focus` for exploring one symbol and its neighborhood
+- `graph` for high-level architecture overviews
+- `analyze` for structural-analysis summaries
+
+Those skills are there to encourage external agents to prefer the AST-backed surface instead of falling back to whole-file reads.
+
+## Why this is useful
+
+The main value of the MCP server is not just “more tools.” It is that those tools are grounded in the same indexed graph that minicode already uses for:
+
+- the code map
+- graph navigation
+- annotations
+- structural analysis
+- live UI activity
+
+That means you get one code-intelligence layer serving multiple surfaces:
+
+- native web UI
+- OpenAI-compatible clients
+- external MCP clients like Claude Code
+
+## Troubleshooting
+
+If the plugin is installed but the tools do not appear:
+
+- make sure `minicode serve` is running
+- confirm the MCP endpoint is reachable at `http://localhost:4567/mcp`
+- rerun `minicode plugin install` to refresh the plugin symlink
+
+If the MCP client connects but returns little or no symbol data:
+
+- make sure the workspace contains supported files
+- remember the deepest built-in indexing path today is TypeScript and JavaScript
+- use plugins if you want to expand language coverage
+
+## Related docs
+
+- [Get Started](/docs/get-started/)
+- [Web UI and Serve Mode](/docs/web-ui-and-serve/)
+- [Plugins and Extensibility](/docs/plugins-and-extensibility/)

--- a/site/content/docs/plugins-and-extensibility.md
+++ b/site/content/docs/plugins-and-extensibility.md
@@ -5,7 +5,7 @@ weight: 50
 kicker: Extensibility
 ---
 
-minicode is built around a plugin-based indexer and a broader runtime architecture that is moving toward a reusable SDK. The plugin system is the main extension point today.
+minicode is built around a plugin-based indexer and a broader runtime architecture that is moving toward a reusable SDK. The plugin system is the main extension point for new language support today, while the MCP server is the main extension point for connecting external agents to the same indexed graph intelligence.
 
 ## Built-in language support
 
@@ -47,6 +47,23 @@ Plugins power:
 - `read_symbol`
 - `find_references`
 - `get_dependencies`
+- `find_path`
+
+## MCP surface for external agents
+
+If you want another agent surface to consume minicode's indexed tooling directly, use the MCP server exposed by `minicode serve`. The bundled Claude Code plugin is the easiest example of that path:
+
+```bash
+minicode serve
+minicode plugin install
+```
+
+That gives external agents access to:
+
+- symbol-aware tools
+- annotations
+- code-map and structural-analysis resources
+- the same live graph activity you can watch in the web UI
 
 At a minimum, a plugin needs to know how to:
 
@@ -87,5 +104,6 @@ That direction would make the runtime reusable in:
 ## Related docs
 
 - [Agent Runtime SDK](/docs/agent-runtime-sdk/)
+- [MCP Server](/docs/mcp-server/)
 - [Technical Docs: Runtime Architecture](/docs/technical/runtime-architecture/)
 - [Technical Docs: Indexing and Graph](/docs/technical/indexing-and-graph/)

--- a/site/content/docs/web-ui-and-serve.md
+++ b/site/content/docs/web-ui-and-serve.md
@@ -1,11 +1,11 @@
 ---
 title: Web UI and Serve Mode
-description: What ships with `minicode serve`, from the chat UI and sessions to the graph endpoints and OpenAI-compatible API.
+description: What ships with `minicode serve`, from the chat UI and settings to structural analysis, MCP, and the OpenAI-compatible API.
 weight: 40
 kicker: Features
 ---
 
-`minicode serve` is the browser-facing side of the project. It starts the local chat UI, the OpenAI-compatible API, and the graph-oriented endpoints that power the dependency-graph experience.
+`minicode serve` is the browser-facing side of the project. It starts the local chat UI, the OpenAI-compatible API, the MCP server, and the graph-oriented endpoints that power the dependency-graph experience.
 
 ## Start serve mode
 
@@ -18,6 +18,7 @@ By default this opens:
 
 - the web UI at `http://localhost:4567`
 - the OpenAI-compatible API at `http://localhost:4567/v1`
+- the MCP endpoint at `http://localhost:4567/mcp`
 - the WebSocket stream at `ws://localhost:4567`
 
 ## What the web UI includes
@@ -30,7 +31,29 @@ The shipped interface supports:
 - full markdown rendering for final responses
 - auto-resize input
 - session save and restore
+- settings editing for persisted non-secret config
+- model switching with sorted provider model lists
+- structural analysis with filtered findings
+- AI explanations for individual structural findings
 - graph view toggle and resizable panes
+
+## Settings and configuration editing
+
+The header includes a `Settings` entry point that opens a modal for editing persisted non-secret config values.
+
+From there you can:
+
+- switch between workspace and global config scope
+- inspect effective, workspace, global, and env-layer values
+- edit persisted defaults for future sessions
+- see when an environment variable is overriding a saved value
+
+The same data is exposed through:
+
+- `GET /api/config` for structured settings metadata
+- `POST /api/config` for persisted updates
+
+Secrets such as API keys still remain env-only.
 
 ## Session management
 
@@ -54,6 +77,17 @@ curl http://localhost:4567/v1/chat/completions \
 
 The API also supports streaming and `GET /v1/models`.
 
+## MCP server
+
+Serve mode also hosts an MCP server at `/mcp`. That gives external agents access to the same indexed code-intelligence surface that powers the web UI.
+
+The current MCP surface includes:
+
+- tools such as `read_symbol`, `find_references`, `get_dependencies`, `search_code_map`, `find_path`, `add_annotation`, and `list_annotations`
+- resources such as `minicode://code-map` and `minicode://structural-analysis`
+
+The bundled `minicode plugin install` command is the easiest path for wiring this into Claude Code.
+
 ## REST endpoints
 
 The serve-mode feature guide documents these main groups of endpoints:
@@ -65,7 +99,8 @@ The serve-mode feature guide documents these main groups of endpoints:
 | `GET` | `/api/status` | Agent status, workspace, model, provider |
 | `GET` | `/api/models` | List models when the provider supports model enumeration |
 | `POST` | `/api/model` | Switch the active model |
-| `GET` | `/api/config` | Formatted agent configuration |
+| `GET` | `/api/config` | Structured editable settings plus formatted config |
+| `POST` | `/api/config` | Persist non-secret config updates to workspace or global scope |
 | `POST` | `/api/chat` | Send a message and get a non-streaming response |
 | `GET` | `/api/sessions` | List saved sessions |
 | `POST` | `/api/sessions/save` | Save current session |
@@ -81,6 +116,8 @@ The serve-mode feature guide documents these main groups of endpoints:
 | `GET` | `/api/symbols/:name/source` | Extracted source for a symbol |
 | `GET` | `/api/code-map` | Ranked code map |
 | `GET` | `/api/graph` | Full dependency graph |
+| `GET` | `/api/analysis` | Deterministic structural-analysis report |
+| `POST` | `/api/analysis/explain` | Stream an AI explanation for one structural finding |
 | `GET` | `/api/focus` | Pinned symbols |
 | `POST` | `/api/focus` | Pin or unpin a symbol |
 
@@ -104,6 +141,9 @@ The current graph experience includes:
 - hover highlighting
 - node detail panels
 - focus pinning
+- live structural analysis with graph-linked findings
+- filtered finding lists by hotspots, cycles, and coupling
+- auto-open details for active graph symbols during live tool activity
 - graph fit, re-layout, and clear actions
 - agent activity pulses when symbol-aware tools run
 
@@ -114,6 +154,17 @@ The web UI also supports symbol-level notes and an `Explain` flow:
 - annotations attach user notes to specific symbols
 - those notes are injected only when relevant tools touch the symbol
 - the explain flow runs a separate research pass for a symbol without polluting the main chat context
+
+## Structural analysis
+
+The graph UI can run a deterministic structural-analysis pass over the current dependency graph. The current report looks for:
+
+- dependency cycles
+- structural hotspots
+- file-level coupling outliers
+- high fan-out orchestration points
+
+The findings drawer is filterable from the summary cards, and selecting a finding highlights the relevant nodes and edges on the graph. Individual findings can also request an AI explanation layered on top of the deterministic report.
 
 ## WebSocket protocol
 
@@ -142,3 +193,4 @@ The WebSocket channel supports:
 
 - [Technical Docs: Product Vision](/docs/technical/product-vision/)
 - [Technical Docs: Indexing and Graph](/docs/technical/indexing-and-graph/)
+- [MCP Server](/docs/mcp-server/)

--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -814,7 +814,8 @@
         </a>
         <nav class="site-nav" aria-label="Primary">
           <a class="{{ if .IsHome }}active{{ end }}" href="/">Overview</a>
-          <a class="{{ if eq .Section "docs" }}active{{ end }}" href="/docs/">Docs</a>
+          <a class="{{ if and (eq .Section "docs") (ne .RelPermalink "/docs/mcp-server/") }}active{{ end }}" href="/docs/">Docs</a>
+          <a class="{{ if eq .RelPermalink "/docs/mcp-server/" }}active{{ end }}" href="/docs/mcp-server/">MCP</a>
           <a href="https://github.com/sean1588/minicode">GitHub</a>
         </nav>
       </header>

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -8,11 +8,13 @@
       <div class="hero-actions">
         <a class="button primary" href="/docs/get-started/">Get started</a>
         <a class="button secondary" href="https://github.com/sean1588/minicode">View on GitHub</a>
+        <a class="button secondary" href="/docs/mcp-server/">MCP server</a>
         <a class="button secondary" href="#how-it-works">See the flow</a>
       </div>
       <ul class="hero-points">
         <li>graph-native web UI</li>
         <li>symbol-aware retrieval</li>
+        <li>mcp + claude plugin</li>
         <li>dependency-cone context</li>
         <li>local + hosted model workflows</li>
       </ul>
@@ -53,18 +55,23 @@
     <div class="section-intro">
       <div class="eyebrow">Product surface</div>
       <h2>More than a single interface</h2>
-      <p>minicode now reads less like a single tool and more like a compact agent platform: a graph-native web app, a coding runtime, an OpenAI-compatible endpoint, and extensible language-aware indexing. Today the deepest built-in indexing path is focused on TypeScript and JavaScript, with plugins leaving room to add more languages over time.</p>
+      <p>minicode now reads less like a single tool and more like a compact agent platform: a graph-native web app, a coding runtime, an MCP server for external agents, an OpenAI-compatible endpoint, and extensible language-aware indexing. Today the deepest built-in indexing path is focused on TypeScript and JavaScript, with plugins leaving room to add more languages over time.</p>
     </div>
-    <div class="grid three-up compact-cards">
+    <div class="grid compact-cards">
       <article>
         <h3>Graph-native web app</h3>
-        <p>Real-time chat, tool streaming, sessions, symbol focus, and a dependency graph that exposes the agent's perspective directly in the interface.</p>
+        <p>Real-time chat, tool streaming, sessions, settings, structural analysis, AI explanations, symbol focus, and a dependency graph that exposes the agent's perspective directly in the interface.</p>
         <div class="card-note">the clearest expression of the idea</div>
       </article>
       <article>
         <h3>Agent runtime</h3>
         <p>Interactive multi-turn coding loop with tools, session trimming, loop protection, and structural context injected into each step.</p>
         <div class="card-note">runtime + tooling core</div>
+      </article>
+      <article>
+        <h3>MCP server + Claude plugin</h3>
+        <p>Expose symbol-aware tools, code-map resources, and structural-analysis findings to external agents while the web UI visualizes the same exploration in real time.</p>
+        <div class="card-note">external agents, same graph intelligence</div>
       </article>
       <article>
         <h3>OpenAI-compatible backend</h3>
@@ -188,6 +195,10 @@
       <article class="use-case">
         <h3>Structural code navigation</h3>
         <p>Best when the right answer lives in code relationships rather than in a single obvious file or folder.</p>
+      </article>
+      <article class="use-case">
+        <h3>External-agent augmentation</h3>
+        <p>Use the MCP server and Claude plugin when you want symbol-aware code intelligence and structural analysis inside another agent surface.</p>
       </article>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- refresh the landing page copy to highlight MCP, Claude plugin support, structural analysis, and the richer web app surface
- add a dedicated MCP Server docs page and link it directly from the top nav
- update get started, CLI, configuration, web UI, and extensibility docs to reflect the current minicode feature set

## Verification
- cd site && hugo