### PR TITLE
Multi-site Pulumi: support N sites, add claudepanion deploy

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - 'sites/minicode/**'
+      - 'sites/**'
       - 'infrastructure/**'
       - '.github/workflows/deploy-site.yml'
   workflow_dispatch:
@@ -12,13 +12,16 @@ on:
 env:
   AWS_REGION: us-west-2
   HUGO_VERSION: '0.147.6'
+  PULUMI_STACK: sean1588/minicode-site/dev
 
 jobs:
-  deploy:
+  infra:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
+    outputs:
+      sites: ${{ steps.outputs.outputs.sites }}
 
     steps:
       - name: Checkout
@@ -35,12 +38,6 @@ jobs:
         working-directory: infrastructure
         run: npm ci
 
-      - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v3
-        with:
-          hugo-version: ${{ env.HUGO_VERSION }}
-          extended: true
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -55,37 +52,75 @@ jobs:
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
         run: |
-          pulumi stack select sean1588/minicode-site/dev --cwd infrastructure
-          pulumi config set aws:region "$AWS_REGION" --cwd infrastructure --stack sean1588/minicode-site/dev
+          pulumi stack select "$PULUMI_STACK" --cwd infrastructure
+          pulumi config set aws:region "$AWS_REGION" --cwd infrastructure --stack "$PULUMI_STACK"
 
       - name: Deploy infrastructure
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-        run: pulumi up --yes --cwd infrastructure --stack sean1588/minicode-site/dev
+        run: pulumi up --yes --cwd infrastructure --stack "$PULUMI_STACK"
 
-      - name: Read infrastructure outputs
-        id: infra
+      - name: Read site outputs
+        id: outputs
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
         run: |
-          echo "bucket=$(pulumi stack output siteBucketName --cwd infrastructure --stack sean1588/minicode-site/dev)" >> "$GITHUB_OUTPUT"
-          echo "cdn_id=$(pulumi stack output siteCdnId --cwd infrastructure --stack sean1588/minicode-site/dev)" >> "$GITHUB_OUTPUT"
-          echo "site_url=$(pulumi stack output siteUrl --cwd infrastructure --stack sean1588/minicode-site/dev)" >> "$GITHUB_OUTPUT"
+          SITES=$(pulumi stack output sitesJson --json --cwd infrastructure --stack "$PULUMI_STACK")
+          echo "sites=$SITES" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    needs: infra
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        site: [minicode, claudepanion]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: ${{ env.HUGO_VERSION }}
+          extended: true
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Read this site's outputs
+        id: site
+        env:
+          SITES_JSON: ${{ needs.infra.outputs.sites }}
+          SITE: ${{ matrix.site }}
+        run: |
+          echo "bucket=$(echo "$SITES_JSON" | jq -r --arg s "$SITE" '.[$s].bucketName')" >> "$GITHUB_OUTPUT"
+          echo "cdn_id=$(echo "$SITES_JSON" | jq -r --arg s "$SITE" '.[$s].cdnId')"      >> "$GITHUB_OUTPUT"
+          echo "url=$(echo    "$SITES_JSON" | jq -r --arg s "$SITE" '.[$s].url')"        >> "$GITHUB_OUTPUT"
 
       - name: Build Hugo site
-        working-directory: sites/minicode
+        working-directory: sites/${{ matrix.site }}
         env:
-          HUGO_BASEURL: ${{ steps.infra.outputs.site_url }}
+          HUGO_BASEURL: ${{ steps.site.outputs.url }}
         run: hugo --minify --baseURL "$HUGO_BASEURL"
 
       - name: Sync files to S3
         run: |
-          aws s3 sync sites/minicode/public/ s3://${{ steps.infra.outputs.bucket }}/ \
+          aws s3 sync sites/${{ matrix.site }}/public/ s3://${{ steps.site.outputs.bucket }}/ \
             --delete \
             --cache-control "public, max-age=300, s-maxage=300"
 
       - name: Invalidate CloudFront
         run: |
           aws cloudfront create-invalidation \
-            --distribution-id ${{ steps.infra.outputs.cdn_id }} \
+            --distribution-id ${{ steps.site.outputs.cdn_id }} \
             --paths '/*'

--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - 'sites/minicode/**'
+      - 'sites/**'
       - 'infrastructure/**'
       - '.github/workflows/deploy-site.yml'
       - '.github/workflows/preview-site.yml'
@@ -13,13 +13,14 @@ on:
 env:
   AWS_REGION: us-west-2
   HUGO_VERSION: '0.147.6'
+  PULUMI_STACK: sean1588/minicode-site/dev
 
 concurrency:
   group: preview-site-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  preview:
+  pulumi-preview:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -40,12 +41,6 @@ jobs:
         working-directory: infrastructure
         run: npm ci
 
-      - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v3
-        with:
-          hugo-version: ${{ env.HUGO_VERSION }}
-          extended: true
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -60,23 +55,32 @@ jobs:
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
         run: |
-          pulumi stack select sean1588/minicode-site/dev --cwd infrastructure
-          pulumi config set aws:region "$AWS_REGION" --cwd infrastructure --stack sean1588/minicode-site/dev
+          pulumi stack select "$PULUMI_STACK" --cwd infrastructure
+          pulumi config set aws:region "$AWS_REGION" --cwd infrastructure --stack "$PULUMI_STACK"
 
       - name: Preview infrastructure
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-        run: pulumi preview --diff --cwd infrastructure --stack sean1588/minicode-site/dev --non-interactive
+        run: pulumi preview --diff --cwd infrastructure --stack "$PULUMI_STACK" --non-interactive
 
-      - name: Read site URL
-        id: infra
-        env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-        run: |
-          echo "site_url=$(pulumi stack output siteUrl --cwd infrastructure --stack sean1588/minicode-site/dev)" >> "$GITHUB_OUTPUT"
+  hugo-build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        site: [minicode, claudepanion]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: ${{ env.HUGO_VERSION }}
+          extended: true
 
       - name: Build Hugo site
-        working-directory: sites/minicode
-        env:
-          HUGO_BASEURL: ${{ steps.infra.outputs.site_url }}
-        run: hugo --minify --baseURL "$HUGO_BASEURL"
+        working-directory: sites/${{ matrix.site }}
+        run: hugo --minify --baseURL "https://${{ matrix.site }}.example.invalid"

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Minimal Hugo + Pulumi bootstrap for `minicode-site`.
 
 ## Repo layout
 
-- `sites/<subdomain>/` — one Hugo project per subdomain (currently `sites/minicode/`)
-- `infrastructure/` — Pulumi program for S3 + CloudFront hosting
-- `.github/workflows/deploy-site.yml` — deploys on push to `main`
-- `.github/workflows/preview-site.yml` — runs `pulumi preview` and a Hugo build on every PR
+- `sites/<subdomain>/` — one Hugo project per subdomain (e.g. `sites/minicode/`, `sites/claudepanion/`)
+- `infrastructure/` — Pulumi program; provisions one S3 bucket + CloudFront distribution + ACM cert + Route53 alias per entry in `minicode-site:sites` config
+- `.github/workflows/deploy-site.yml` — deploys on push to `main` (matrix-fans-out one job per site)
+- `.github/workflows/preview-site.yml` — runs `pulumi preview` + a Hugo build for each site on every PR
 
 ## Local site work
 
@@ -42,10 +42,25 @@ pulumi up
 Useful outputs:
 
 ```bash
+# All sites at once (returns a JSON map keyed by site name)
+pulumi stack output sitesJson --json
+
+# Backwards-compatible shortcuts for the primary site (currently minicode)
 pulumi stack output siteBucketName
 pulumi stack output siteCdnId
 pulumi stack output siteUrl
 ```
+
+To add a new site, append a block to `minicode-site:sites` in `Pulumi.dev.yaml`:
+
+```yaml
+- name: example
+  resourcePrefix: example
+  domainName: example.seanholung.com
+  # certificateArn: <us-east-1 ACM ARN>   # omit to provision a fresh cert + DNS validation
+```
+
+Then add the site key to the `matrix.site` list in both deploy and preview workflows, and create the corresponding `sites/example/` Hugo project.
 
 ## GitHub Actions
 

--- a/infrastructure/Pulumi.dev.yaml
+++ b/infrastructure/Pulumi.dev.yaml
@@ -1,5 +1,11 @@
 config:
   aws:region: us-west-2
-  minicode-site:domainName: minicode.seanholung.com
   minicode-site:hostedZoneName: seanholung.com
-  minicode-site:certificateArn: arn:aws:acm:us-east-1:127590312302:certificate/2b25457c-334d-4e02-b013-a49994f5e67a
+  minicode-site:sites:
+    - name: minicode
+      resourcePrefix: site
+      domainName: minicode.seanholung.com
+      certificateArn: arn:aws:acm:us-east-1:127590312302:certificate/2b25457c-334d-4e02-b013-a49994f5e67a
+    - name: claudepanion
+      resourcePrefix: claudepanion
+      domainName: claudepanion.seanholung.com

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -1,18 +1,39 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 
+interface SiteConfig {
+  name: string;            // logical site key (e.g. "minicode", "claudepanion")
+  resourcePrefix: string;  // Pulumi resource name prefix; "site" preserves the original URNs
+  domainName: string;
+  certificateArn?: string; // when set, cert creation/validation is skipped
+}
+
+interface CreateSiteArgs extends SiteConfig {
+  awsResourceName: string; // used for AWS-level naming + tags (e.g. "minicode-site")
+  hostedZone: pulumi.Output<aws.route53.GetZoneResult>;
+  usEast1: aws.Provider;
+}
+
+interface SiteOutputs {
+  bucketName: pulumi.Output<string>;
+  bucketArn: pulumi.Output<string>;
+  cdnId: pulumi.Output<string>;
+  cdnDomain: pulumi.Output<string>;
+  domain: string;
+  url: pulumi.Output<string>;
+}
+
 const config = new pulumi.Config();
-const siteName = config.get("siteName") || "minicode-site";
-const domainName = config.get("domainName") || "minicode.seanholung.com";
+const projectName = config.get("projectName") || "minicode-site";
 const hostedZoneName = config.get("hostedZoneName") || "seanholung.com";
-const configuredCertificateArn = config.get("certificateArn");
+const sites = config.requireObject<SiteConfig[]>("sites");
 
 function validateCloudFrontCertificateArn(certificateArn: string): string {
   const arnParts = certificateArn.split(":");
 
   if (arnParts.length < 6 || arnParts[2] !== "acm") {
     throw new Error(
-      `minicode-site:certificateArn must be an ACM certificate ARN. Received "${certificateArn}".`
+      `certificateArn must be an ACM certificate ARN. Received "${certificateArn}".`
     );
   }
 
@@ -20,7 +41,7 @@ function validateCloudFrontCertificateArn(certificateArn: string): string {
 
   if (certificateRegion !== "us-east-1") {
     throw new Error(
-      `CloudFront requires ACM certificates in us-east-1. Received "${certificateRegion}" in minicode-site:certificateArn.`
+      `CloudFront requires ACM certificates in us-east-1. Received "${certificateRegion}" in certificateArn.`
     );
   }
 
@@ -36,36 +57,42 @@ const hostedZone = aws.route53.getZoneOutput({
   privateZone: false,
 });
 
-const siteBucket = new aws.s3.Bucket("site", {
-  forceDestroy: false,
-  tags: {
-    Project: siteName,
+function createSite(args: CreateSiteArgs): SiteOutputs {
+  const { resourcePrefix, awsResourceName, domainName, certificateArn } = args;
+  const displayName = args.name.charAt(0).toUpperCase() + args.name.slice(1);
+
+  const tags = {
+    Project: awsResourceName,
     Component: "marketing-site",
-  },
-});
+  };
 
-new aws.s3.BucketPublicAccessBlock("site-public-access", {
-  bucket: siteBucket.id,
-  blockPublicAcls: true,
-  blockPublicPolicy: true,
-  ignorePublicAcls: true,
-  restrictPublicBuckets: true,
-});
+  const siteBucket = new aws.s3.Bucket(resourcePrefix, {
+    forceDestroy: false,
+    tags,
+  });
 
-const oac = new aws.cloudfront.OriginAccessControl("site-oac", {
-  name: `${siteName}-oac`,
-  description: "CloudFront access for Minicode site bucket",
-  originAccessControlOriginType: "s3",
-  signingBehavior: "always",
-  signingProtocol: "sigv4",
-});
+  new aws.s3.BucketPublicAccessBlock(`${resourcePrefix}-public-access`, {
+    bucket: siteBucket.id,
+    blockPublicAcls: true,
+    blockPublicPolicy: true,
+    ignorePublicAcls: true,
+    restrictPublicBuckets: true,
+  });
 
-const prettyUrlRewriter = new aws.cloudfront.Function("site-pretty-url-rewriter", {
-  name: `${siteName}-pretty-url-rewriter`,
-  runtime: "cloudfront-js-2.0",
-  comment: "Rewrites directory-style paths to index.html for static-site routing",
-  publish: true,
-  code: `function handler(event) {
+  const oac = new aws.cloudfront.OriginAccessControl(`${resourcePrefix}-oac`, {
+    name: `${awsResourceName}-oac`,
+    description: `CloudFront access for ${displayName} site bucket`,
+    originAccessControlOriginType: "s3",
+    signingBehavior: "always",
+    signingProtocol: "sigv4",
+  });
+
+  const prettyUrlRewriter = new aws.cloudfront.Function(`${resourcePrefix}-pretty-url-rewriter`, {
+    name: `${awsResourceName}-pretty-url-rewriter`,
+    runtime: "cloudfront-js-2.0",
+    comment: "Rewrites directory-style paths to index.html for static-site routing",
+    publish: true,
+    code: `function handler(event) {
   var request = event.request;
   var uri = request.uri;
 
@@ -84,149 +111,166 @@ const prettyUrlRewriter = new aws.cloudfront.Function("site-pretty-url-rewriter"
 
   return request;
 }`,
-});
+  });
 
-const existingCertificateArn = configuredCertificateArn
-  ? validateCloudFrontCertificateArn(configuredCertificateArn)
-  : undefined;
+  let viewerCertificateArn: pulumi.Input<string>;
+  const certificateDependencies: pulumi.Resource[] = [];
 
-let viewerCertificateArn: pulumi.Input<string>;
-const certificateDependencies: pulumi.Resource[] = [];
-
-if (existingCertificateArn) {
-  viewerCertificateArn = existingCertificateArn;
-} else {
-  const certificate = new aws.acm.Certificate(
-    "site-certificate",
-    {
-      domainName,
-      validationMethod: "DNS",
-      tags: {
-        Project: siteName,
-        Component: "marketing-site",
+  if (certificateArn) {
+    viewerCertificateArn = validateCloudFrontCertificateArn(certificateArn);
+  } else {
+    const certificate = new aws.acm.Certificate(
+      `${resourcePrefix}-certificate`,
+      {
+        domainName,
+        validationMethod: "DNS",
+        tags,
       },
+      { provider: args.usEast1 }
+    );
+
+    const certificateValidationOption = certificate.domainValidationOptions[0];
+
+    const certificateValidationRecord = new aws.route53.Record(`${resourcePrefix}-certificate-validation`, {
+      zoneId: args.hostedZone.zoneId,
+      name: certificateValidationOption.resourceRecordName,
+      type: certificateValidationOption.resourceRecordType,
+      records: [certificateValidationOption.resourceRecordValue],
+      ttl: 60,
+      allowOverwrite: true,
+    });
+
+    const certificateValidation = new aws.acm.CertificateValidation(
+      `${resourcePrefix}-certificate-validation-result`,
+      {
+        certificateArn: certificate.arn,
+        validationRecordFqdns: [certificateValidationRecord.fqdn],
+      },
+      { provider: args.usEast1 }
+    );
+
+    viewerCertificateArn = certificate.arn;
+    certificateDependencies.push(certificateValidation);
+  }
+
+  const cdn = new aws.cloudfront.Distribution(`${resourcePrefix}-cdn`, {
+    enabled: true,
+    comment: `${displayName} static site`,
+    defaultRootObject: "index.html",
+    priceClass: "PriceClass_100",
+    httpVersion: "http2and3",
+    aliases: [domainName],
+    origins: [
+      {
+        domainName: siteBucket.bucketRegionalDomainName,
+        originId: "s3-site",
+        originAccessControlId: oac.id,
+      },
+    ],
+    defaultCacheBehavior: {
+      targetOriginId: "s3-site",
+      viewerProtocolPolicy: "redirect-to-https",
+      allowedMethods: ["GET", "HEAD", "OPTIONS"],
+      cachedMethods: ["GET", "HEAD"],
+      compress: true,
+      cachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
+      functionAssociations: [
+        {
+          eventType: "viewer-request",
+          functionArn: prettyUrlRewriter.arn,
+        },
+      ],
     },
-    { provider: usEast1 }
-  );
+    customErrorResponses: [
+      {
+        errorCode: 403,
+        responseCode: 200,
+        responsePagePath: "/index.html",
+        errorCachingMinTtl: 10,
+      },
+      {
+        errorCode: 404,
+        responseCode: 200,
+        responsePagePath: "/index.html",
+        errorCachingMinTtl: 10,
+      },
+    ],
+    restrictions: {
+      geoRestriction: { restrictionType: "none" },
+    },
+    viewerCertificate: {
+      acmCertificateArn: viewerCertificateArn,
+      sslSupportMethod: "sni-only",
+      minimumProtocolVersion: "TLSv1.2_2021",
+    },
+    tags,
+  }, { dependsOn: certificateDependencies });
 
-  const certificateValidationOption = certificate.domainValidationOptions[0];
+  new aws.s3.BucketPolicy(`${resourcePrefix}-policy`, {
+    bucket: siteBucket.id,
+    policy: pulumi
+      .all([siteBucket.arn, cdn.arn])
+      .apply(([bucketArn, cdnArn]) =>
+        JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Sid: "AllowCloudFrontServicePrincipal",
+              Effect: "Allow",
+              Principal: { Service: "cloudfront.amazonaws.com" },
+              Action: "s3:GetObject",
+              Resource: `${bucketArn}/*`,
+              Condition: { StringEquals: { "AWS:SourceArn": cdnArn } },
+            },
+          ],
+        })
+      ),
+  });
 
-  const certificateValidationRecord = new aws.route53.Record("site-certificate-validation", {
-    zoneId: hostedZone.zoneId,
-    name: certificateValidationOption.resourceRecordName,
-    type: certificateValidationOption.resourceRecordType,
-    records: [certificateValidationOption.resourceRecordValue],
-    ttl: 60,
+  new aws.route53.Record(`${resourcePrefix}-alias-record`, {
+    zoneId: args.hostedZone.zoneId,
+    name: domainName,
+    type: "A",
+    aliases: [
+      {
+        name: cdn.domainName,
+        zoneId: cdn.hostedZoneId,
+        evaluateTargetHealth: false,
+      },
+    ],
     allowOverwrite: true,
   });
 
-  const certificateValidation = new aws.acm.CertificateValidation(
-    "site-certificate-validation-result",
-    {
-      certificateArn: certificate.arn,
-      validationRecordFqdns: [certificateValidationRecord.fqdn],
-    },
-    { provider: usEast1 }
-  );
-
-  viewerCertificateArn = certificate.arn;
-  certificateDependencies.push(certificateValidation);
+  return {
+    bucketName: siteBucket.bucket,
+    bucketArn: siteBucket.arn,
+    cdnId: cdn.id,
+    cdnDomain: cdn.domainName,
+    domain: domainName,
+    url: pulumi.interpolate`https://${domainName}`,
+  };
 }
 
-const cdn = new aws.cloudfront.Distribution("site-cdn", {
-  enabled: true,
-  comment: "Minicode static site",
-  defaultRootObject: "index.html",
-  priceClass: "PriceClass_100",
-  httpVersion: "http2and3",
-  aliases: [domainName],
-  origins: [
-    {
-      domainName: siteBucket.bucketRegionalDomainName,
-      originId: "s3-site",
-      originAccessControlId: oac.id,
-    },
-  ],
-  defaultCacheBehavior: {
-    targetOriginId: "s3-site",
-    viewerProtocolPolicy: "redirect-to-https",
-    allowedMethods: ["GET", "HEAD", "OPTIONS"],
-    cachedMethods: ["GET", "HEAD"],
-    compress: true,
-    cachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
-    functionAssociations: [
-      {
-        eventType: "viewer-request",
-        functionArn: prettyUrlRewriter.arn,
-      },
-    ],
-  },
-  customErrorResponses: [
-    {
-      errorCode: 403,
-      responseCode: 200,
-      responsePagePath: "/index.html",
-      errorCachingMinTtl: 10,
-    },
-    {
-      errorCode: 404,
-      responseCode: 200,
-      responsePagePath: "/index.html",
-      errorCachingMinTtl: 10,
-    },
-  ],
-  restrictions: {
-    geoRestriction: { restrictionType: "none" },
-  },
-  viewerCertificate: {
-    acmCertificateArn: viewerCertificateArn,
-    sslSupportMethod: "sni-only",
-    minimumProtocolVersion: "TLSv1.2_2021",
-  },
-  tags: {
-    Project: siteName,
-    Component: "marketing-site",
-  },
-}, { dependsOn: certificateDependencies });
+const siteOutputs: Record<string, SiteOutputs> = {};
+for (const site of sites) {
+  siteOutputs[site.name] = createSite({
+    ...site,
+    awsResourceName: `${site.name}-site`,
+    hostedZone,
+    usEast1,
+  });
+}
 
-new aws.s3.BucketPolicy("site-policy", {
-  bucket: siteBucket.id,
-  policy: pulumi
-    .all([siteBucket.arn, cdn.arn])
-    .apply(([bucketArn, cdnArn]) =>
-      JSON.stringify({
-        Version: "2012-10-17",
-        Statement: [
-          {
-            Sid: "AllowCloudFrontServicePrincipal",
-            Effect: "Allow",
-            Principal: { Service: "cloudfront.amazonaws.com" },
-            Action: "s3:GetObject",
-            Resource: `${bucketArn}/*`,
-            Condition: { StringEquals: { "AWS:SourceArn": cdnArn } },
-          },
-        ],
-      })
-    ),
-});
+// Per-site outputs. Read in CI as `pulumi stack output sitesJson --json` and
+// index by site name (e.g. .minicode.bucketName, .claudepanion.cdnId).
+export const sitesJson = pulumi.output(siteOutputs);
 
-new aws.route53.Record("site-alias-record", {
-  zoneId: hostedZone.zoneId,
-  name: domainName,
-  type: "A",
-  aliases: [
-    {
-      name: cdn.domainName,
-      zoneId: cdn.hostedZoneId,
-      evaluateTargetHealth: false,
-    },
-  ],
-  allowOverwrite: true,
-});
-
-export const siteBucketName = siteBucket.bucket;
-export const siteBucketArn = siteBucket.arn;
-export const siteCdnId = cdn.id;
-export const siteCdnDomain = cdn.domainName;
-export const siteDomain = domainName;
-export const siteUrl = pulumi.interpolate`https://${domainName}`;
+// Backwards-compatible top-level outputs for the legacy single-site workflow.
+// Resolve to the first site declared in config (which is minicode today).
+const primary = siteOutputs[sites[0].name];
+export const siteBucketName = primary.bucketName;
+export const siteBucketArn = primary.bucketArn;
+export const siteCdnId = primary.cdnId;
+export const siteCdnDomain = primary.cdnDomain;
+export const siteDomain = primary.domain;
+export const siteUrl = primary.url;


### PR DESCRIPTION
## Summary
- Refactors \`infrastructure/index.ts\` from a single hardcoded site to a \`createSite()\` function that provisions a full per-site stack (bucket + OAC + CloudFront function + ACM cert in us-east-1 + DNS validation + distribution + bucket policy + Route53 alias) for each entry in \`minicode-site:sites\` config
- Adds \`claudepanion.seanholung.com\` as the second site alongside \`minicode.seanholung.com\`
- Splits \`deploy-site.yml\` into an \`infra\` job (\`pulumi up\` + emit \`sites\` outputs) and a matrixed \`deploy\` job that builds + syncs + invalidates each site in parallel
- \`preview-site.yml\` does \`pulumi preview\` plus a parallel Hugo build per site

## URN preservation (the load-bearing concern)
Minicode keeps its existing Pulumi resource names (prefix \`site\`), so the resulting \`pulumi up\` should show **only adds** for claudepanion's resources, with **zero updates / deletes** to the live minicode bucket, distribution, or cert. The \`preview-site\` job on this PR runs \`pulumi preview --diff\` so we can confirm before merge.

The minicode display strings (\"Minicode static site\", \"CloudFront access for Minicode site bucket\") are preserved exactly via a \`displayName\` derived from the site \`name\`, so even cosmetic property updates are avoided.

## Stack outputs
- New \`sitesJson\` — JSON map keyed by site name, used by the matrixed deploy job
- Legacy \`siteBucketName\` / \`siteCdnId\` / \`siteUrl\` etc. preserved as aliases of the first declared site (minicode) so any external readers don't break

## To add a new site later
1. Append an entry to \`minicode-site:sites\` in \`Pulumi.dev.yaml\` (\`name\`, \`resourcePrefix\`, \`domainName\`, optional \`certificateArn\`)
2. Add the site key to the \`matrix.site\` list in both workflows
3. Create the \`sites/<name>/\` Hugo project

## Test plan
- [x] \`tsc --noEmit\` clean on \`infrastructure/index.ts\`
- [x] \`hugo --minify\` from both \`sites/minicode\` and \`sites/claudepanion\` builds clean
- [ ] **\`preview-site\` job on this PR shows only adds for claudepanion** — review the \`pulumi preview --diff\` output before approving
- [ ] After merge, \`deploy\` job's matrix produces both \`minicode.seanholung.com\` and \`claudepanion.seanholung.com\`
- [ ] DNS resolves and HTTPS works for the new domain (ACM + Route53 alias)

🤖 Generated with [Claude Code](https://claude.com/claude-code)