### PR TITLE
Fix deploy workflow output + reuse wildcard cert for claudepanion

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -65,7 +65,10 @@ jobs:
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
         run: |
-          SITES=$(pulumi stack output sitesJson --json --cwd infrastructure --stack "$PULUMI_STACK")
+          # Compact JSON onto a single line — $GITHUB_OUTPUT rejects multi-line
+          # values without the heredoc delimiter, which the pretty-printed
+          # `pulumi stack output --json` would otherwise trip on.
+          SITES=$(pulumi stack output sitesJson --json --cwd infrastructure --stack "$PULUMI_STACK" | jq -c .)
           echo "sites=$SITES" >> "$GITHUB_OUTPUT"
 
   deploy:

--- a/infrastructure/Pulumi.dev.yaml
+++ b/infrastructure/Pulumi.dev.yaml
@@ -9,3 +9,5 @@ config:
     - name: claudepanion
       resourcePrefix: claudepanion
       domainName: claudepanion.seanholung.com
+      # Reuse the existing wildcard cert (SANs: seanholung.com, *.seanholung.com)
+      certificateArn: arn:aws:acm:us-east-1:127590312302:certificate/2b25457c-334d-4e02-b013-a49994f5e67a


### PR DESCRIPTION
## Summary

Two fixes folded into one PR — the second deploy needs to happen anyway, so making it do both work items at once is cheaper than two consecutive runs.

### 1. \`pulumi stack output\` → \$GITHUB_OUTPUT
\`pulumi stack output sitesJson --json\` is pretty-printed and spans multiple lines, which \`\$GITHUB_OUTPUT\` rejects. Pipe through \`jq -c .\` to compact onto one line so the matrixed deploy job receives the JSON intact.

PR #24's deploy created all 10 claudepanion AWS resources cleanly; only the post-up output-pass step blew up. After merging this PR the workflow rerun is a no-op on infra (excluding the cert change below) and the matrix deploy actually fans out.

### 2. Reuse the existing wildcard cert
Verified the live cert SANs via \`openssl s_client\`:
\`\`\`
DNS:seanholung.com, DNS:*.seanholung.com
\`\`\`
So the new cert PR #24 provisioned is redundant. Pinning \`certificateArn\` on the claudepanion entry will, on the next \`pulumi up\`:
- Update \`claudepanion-cdn\` viewer cert to the wildcard ARN
- Delete \`claudepanion-certificate\`, \`claudepanion-certificate-validation\` (DNS record), \`claudepanion-certificate-validation-result\`

## Test plan
- [ ] \`pulumi preview\` on this PR shows: 1 update (claudepanion-cdn viewer cert) + 3 deletes (claudepanion cert + validation + validation-result), 0 changes elsewhere
- [ ] After merge: deploy workflow's \`infra\` job applies the cert swap, \`deploy\` matrix completes for both sites
- [ ] \`claudepanion.seanholung.com\` resolves with valid TLS via the wildcard cert

🤖 Generated with [Claude Code](https://claude.com/claude-code)