### PR TITLE
Wire mise CTAs to app.mise.seanholung.com

### DIFF
--- a/sites/mise/layouts/_default/baseof.html
+++ b/sites/mise/layouts/_default/baseof.html
@@ -170,7 +170,7 @@
       <div class="nav-links">
         <a href="#how" class="nav-link">How it works</a>
         <a href="#privacy" class="nav-link">Privacy</a>
-        <a href="#start" class="nav-cta">Start free →</a>
+        <a href="https://app.mise.seanholung.com" class="nav-cta">Start free →</a>
       </div>
     </nav>
 

--- a/sites/mise/layouts/index.html
+++ b/sites/mise/layouts/index.html
@@ -425,8 +425,8 @@
     <h1>A dashboard <br />that runs <em>entirely</em><br /> in <span class="underline">your browser.</span></h1>
     <p class="hero-sub">Drop a CSV or paste a public URL. Mise reads the shape once, lays out the widgets, and renders the dashboard right there in your tab. No accounts, no servers holding your rows — we see your data for a few seconds, then forget it.</p>
     <div class="hero-cta-row">
-      <a href="#start" class="btn btn-primary">Sauté it ↗</a>
-      <a href="#demo" class="btn btn-ghost">See it live</a>
+      <a href="https://app.mise.seanholung.com" class="btn btn-primary">Sauté it ↗</a>
+      <a href="https://app.mise.seanholung.com" class="btn btn-ghost">See it live</a>
       <span class="hero-meta">No signup. No saved data. Yours in ~12 seconds.</span>
     </div>
   </section>
@@ -588,7 +588,7 @@
       <h2 class="section-title">Make your <em>first dashboard</em>.</h2>
       <p class="closing-sub">No card. No signup. No saved data. Drop a file, see your dashboard, export it as HTML and take it with you.</p>
       <div class="closing-row">
-        <a href="#" class="btn btn-primary">Sauté your data ↗</a>
+        <a href="https://app.mise.seanholung.com" class="btn btn-primary">Sauté your data ↗</a>
         <a href="#" class="btn btn-ghost">Read the docs</a>
       </div>
     </div>


### PR DESCRIPTION
Point the four conversion CTAs (nav `Start free →`, hero `Sauté it` + `See it live`, closing `Sauté your data`) at `https://app.mise.seanholung.com` instead of in-page anchors. The app subdomain doesn't resolve yet — placeholder until the app is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)