### PR TITLE
mise hero: include JSON in supported drop formats

### DIFF
--- a/sites/mise/layouts/index.html
+++ b/sites/mise/layouts/index.html
@@ -423,7 +423,7 @@
   <section class="hero">
     <div class="hero-eyebrow">mise en place — for your data</div>
     <h1>A dashboard <br />that runs <em>entirely</em><br /> in <span class="underline">your browser.</span></h1>
-    <p class="hero-sub">Drop a CSV or paste a public URL. Mise reads the shape once, lays out the widgets, and renders the dashboard right there in your tab. No accounts, no servers holding your rows — we see your data for a few seconds, then forget it.</p>
+    <p class="hero-sub">Drop a CSV or JSON, or paste a public URL. Mise reads the shape once, lays out the widgets, and renders the dashboard right there in your tab. No accounts, no servers holding your rows — we see your data for a few seconds, then forget it.</p>
     <div class="hero-cta-row">
       <a href="https://app.mise.seanholung.com" class="btn btn-primary">Sauté it ↗</a>
       <a href="https://app.mise.seanholung.com" class="btn btn-ghost">See it live</a>


### PR DESCRIPTION
Was: "Drop a CSV or paste a public URL."
Now: "Drop a CSV or JSON, or paste a public URL."

Aligns hero copy with the doorways section ("CSV, JSON, XLSX, or paste").

🤖 Generated with [Claude Code](https://claude.com/claude-code)